### PR TITLE
Test

### DIFF
--- a/src/AnnotationSetManagement.tsx
+++ b/src/AnnotationSetManagement.tsx
@@ -109,7 +109,6 @@ export default function AnnotationSetManagement() {
               variant="warning"
               className="me-2"
               onClick={() => { 
-                // select only this set
                 setSelectedSets([id]);
                 setEditSetName(name);
                 showModal('editAnnotationSet') 
@@ -132,6 +131,17 @@ export default function AnnotationSetManagement() {
             >
               Export
             </Button>
+              <Button 
+              variant="info"
+              className="fixed-width-button"
+              onClick={() => {
+                setSelectedSets([id]);
+                showModal('moveObservations') 
+              }}
+            >
+              Move Observations
+            </Button>
+            
         </span>
         // <Form.Check
         //   id="custom-switch"
@@ -196,15 +206,6 @@ export default function AnnotationSetManagement() {
           <Button variant="primary" disabled={selectedSets.length == 0} className="me-2" onClick={() => showModal('launchRegistration')}>
             Launch registration task
           </Button>
-          {/* WIP*/}
-          {process.env.NODE_ENV !== 'production' && (
-          <Button 
-              variant="primary"
-              onClick={() => showModal("moveObservations")}
-              disabled={selectedSets.length === 0}
-            >
-              Move Observations
-            </Button> )}
           </span>
         </Col>
         </div>

--- a/src/MoveObservations.tsx
+++ b/src/MoveObservations.tsx
@@ -1,8 +1,7 @@
 import { useState, useContext, useEffect } from 'react';
 import { Modal, Button, Form } from 'react-bootstrap';
 import { AnnotationSetDropdown } from './AnnotationSetDropDown';
-import { ManagementContext, GlobalContext } from './Context';
-import { MultiAnnotationSetDropdown } from './MultiAnnotationSetDropDown';
+import { ManagementContext, GlobalContext, ProjectContext } from './Context';
 import { fetchAllPaginatedResults } from "./utils";
 import { useUpdateProgress } from './useUpdateProgress';
 import LabeledToggleSwitch from './LabeledToggleSwitch';
@@ -16,9 +15,10 @@ type MoveObservationsProps = {
 }
 
 export default function MoveObservations({ show, handleClose, selectedAnnotationSets, setSelectedAnnotationSets }: MoveObservationsProps) {
-    const { allUsers, locationSetsHook: { data: locationSets } } = useContext(ManagementContext)!;
+    const { allUsers, annotationSetsHook: { data: annotationSets, create: createAnnotationSet } } = useContext(ManagementContext)!;
     const { client } = useContext(GlobalContext)!;
-
+    const { project } = useContext(ProjectContext)!;
+    
     const [setObservationsFetched, setTotalObservationsFetched] = useUpdateProgress({
         taskId: `Fetching observations`,
         indeterminateTaskName: `Fetching observations`,
@@ -35,16 +35,17 @@ export default function MoveObservations({ show, handleClose, selectedAnnotation
 
     const [selectedUserId, setSelectedUserId] = useState<string>('');
     const [observationTime, setObservationTime] = useState<number | ''>('');
-    const [newAnnotationSetId, setNewAnnotationSetId] = useState<string>(''); 
+    const [existingAnnotationSetId, setExistingAnnotationSetId] = useState<string>(''); 
     const [filterByUser, setFilterByUser] = useState<boolean>(true);
     const [selectedLocationSets, setSelectedLocationSets] = useState<string[]>([]);
+    const [moveToNewAnnotationSet, setMoveToNewAnnotationSet] = useState<boolean>(true);
 
     const handleMove = async () => {
-        if (selectedAnnotationSets.includes(newAnnotationSetId)) {
+        if (!moveToNewAnnotationSet && selectedAnnotationSets.includes(existingAnnotationSetId)) {
             alert("Cannot move observations to the same annotation set");
             return;
         }
-        
+
         const criteria: {
             owner?: { contains: string };
             timeTaken?: { le: number };
@@ -59,41 +60,66 @@ export default function MoveObservations({ show, handleClose, selectedAnnotation
         }
 
         // For every annotation set, find all observations that match the criteria and move them to the new annotation set.
-        for (const setId of selectedAnnotationSets) {
-            setObservationsFetched(0);
-            setTotalObservationsFetched(0);
-            const observations = await fetchAllPaginatedResults(client.models.Observation.observationsByAnnotationSetId, 
-                {
-                    annotationSetId: setId, 
-                    selectionSet: ['id', 'location.setId'] as const,
-                    filter: criteria
-                },
-                setObservationsFetched
-            ); 
+        setObservationsFetched(0);
+        setTotalObservationsFetched(0);
+        const observations = await fetchAllPaginatedResults(client.models.Observation.observationsByAnnotationSetId, 
+            {
+                annotationSetId: selectedAnnotationSets[0], 
+                selectionSet: ['id', 'location.setId'] as const,
+                filter: criteria
+            },
+            setObservationsFetched
+        ); 
 
-            // filter observations to those that are in the selected location sets
-            const filteredObservations = observations.filter(observation => selectedLocationSets.includes(observation.location.setId));
+        setTotalObservationsFetched(observations.length);
 
-            setTotalObservationsFetched(filteredObservations.length);
+        const filteredObservations = selectedLocationSets.length > 0 
+            ? observations.filter(observation => selectedLocationSets.includes(observation.location?.setId || ''))
+            : observations;
 
-            // move observations to new/other annotation set
-            setObservationsUpdated(0);
-            setTotalObservationsUpdated(filteredObservations.length);
-            for (const observation of filteredObservations) {
-                await client.models.Observation.update({
-                    id: observation.id,
-                    annotationSetId: newAnnotationSetId
-                });
+        if (!confirm(`Are you sure you want to move ${filteredObservations.length} observations${selectedLocationSets.length > 0 ? ` (filtered)` : ''}?`)) {
+            return;
+        }
 
-                setObservationsUpdated(prev => prev + 1);
-            }
+        const previousAnnotationSetName = (annotationSets.find(set => set.id === selectedAnnotationSets[0])?.name || 'set').replace(/ /g, '_');
+        const user = allUsers.find(user => user.id === selectedUserId)?.name;
+        let targetAnnotationSetId = '';
+        if (moveToNewAnnotationSet) {
+            targetAnnotationSetId = createAnnotationSet(
+                { 
+                    // name format: M(moved observation) - previous annotation set name - criteria
+                    name: `M_${
+                        previousAnnotationSetName.length <= 10
+                            ? previousAnnotationSetName
+                            : `${previousAnnotationSetName.slice(0, 5)}_${previousAnnotationSetName.slice(-4)}`
+                    }_${
+                        criteria.owner ? user : criteria.timeTaken ? observationTime : ''
+                    }`, 
+                    projectId: project.id 
+                }
+            );
+            
+        } else {
+            targetAnnotationSetId = existingAnnotationSetId;
+        }
+
+        // move observations to new/other annotation set
+        setObservationsUpdated(0);
+        setTotalObservationsUpdated(filteredObservations.length);
+        for (const observation of filteredObservations) {
+            await client.models.Observation.update({
+                id: observation.id,
+                annotationSetId: targetAnnotationSetId
+            });
+
+            setObservationsUpdated(prev => prev + 1);
         }
     };
 
     useEffect(() => {
         setSelectedUserId('');
         setObservationTime('');
-        setNewAnnotationSetId('');
+        setExistingAnnotationSetId('');
         setSelectedLocationSets([]);
     }, [show]);
 
@@ -104,11 +130,12 @@ export default function MoveObservations({ show, handleClose, selectedAnnotation
             </Modal.Header>
             <Modal.Body>
                 <Form style={{display: 'flex', flexDirection: 'column', gap: '4px'}}>
-                    <Form.Group controlId="formAnnotationSets">
-                        <Form.Label>Select Annotation Sets</Form.Label>
-                        <MultiAnnotationSetDropdown
-                            selectedSets={selectedAnnotationSets}
-                            setAnnotationSets={setSelectedAnnotationSets}
+                    <Form.Group controlId="formAnnotationSet">
+                        <Form.Label>Select Annotation Set</Form.Label>
+                        <AnnotationSetDropdown 
+                            selectedSet={selectedAnnotationSets[0]} 
+                            setAnnotationSet={(set) => setSelectedAnnotationSets([set])} 
+                            canCreate={false}
                         />
                     </Form.Group>
                     <Form.Group controlId="formLocationSets">
@@ -130,12 +157,13 @@ export default function MoveObservations({ show, handleClose, selectedAnnotation
                         /> 
                     </Form.Group>
                     <Form.Group controlId="formUser">
-                        <Form.Label>Select User</Form.Label>
+                        <Form.Label style={{display: filterByUser ? 'block' : 'none'}}>Select User</Form.Label>
                         <Form.Control
                             as="select"
                             value={selectedUserId}
                             onChange={(e) => setSelectedUserId(e.target.value)}
                             disabled={!filterByUser}
+                            hidden={!filterByUser}
                         >
                             <option value="">Choose...</option>
                             {allUsers.map((user) => (
@@ -146,25 +174,37 @@ export default function MoveObservations({ show, handleClose, selectedAnnotation
                         </Form.Control>
                     </Form.Group>
                     <Form.Group controlId="formTime">
-                        <Form.Label>Maximum Observation Time (milliseconds)</Form.Label>
+                        <Form.Label style={{display: !filterByUser ? 'block' : 'none'}}>Maximum Observation Time (milliseconds)</Form.Label>
                         <Form.Control
                             type="number"
                             placeholder="Enter time taken"
                             value={observationTime}
                             onChange={(e) => setObservationTime(e.target.value === '' ? '' : Number(e.target.value) < 0 ? 0 : Number(e.target.value))}
                             disabled={filterByUser}
+                            hidden={filterByUser}
                         />
                     </Form.Group>
                     <Form.Group>
-                    <Form.Label>Move to Annotation Set</Form.Label>
+                        <Form.Label>Move to * annotation set</Form.Label>
+                        <LabeledToggleSwitch
+                            leftLabel="Existing"
+                            rightLabel="New"
+                            checked={moveToNewAnnotationSet}
+                            onChange={(checked) => {
+                                setMoveToNewAnnotationSet(checked);
+                            }}
+                        /> 
+                    </Form.Group>
+                    <Form.Group style={{display: !moveToNewAnnotationSet ? 'block' : 'none'}}>
                         <AnnotationSetDropdown 
-                            selectedSet={newAnnotationSetId} 
-                            setAnnotationSet={setNewAnnotationSetId} 
+                            selectedSet={existingAnnotationSetId} 
+                            setAnnotationSet={setExistingAnnotationSetId} 
+                            canCreate={false}
                         />
                     </Form.Group>
                 </Form>
-                <small className="text-muted">
-                    Note: Provide either a user or observation time to filter observations.
+                <small style={{display: moveToNewAnnotationSet ? 'block' : 'none'}} className="text-muted">
+                    Note: A new set will automatically be created with a unique name.
                 </small>
             </Modal.Body>
             <Modal.Footer>
@@ -175,7 +215,7 @@ export default function MoveObservations({ show, handleClose, selectedAnnotation
                     variant="primary"
                     onClick={() => {handleClose(); handleMove();}}
                     disabled={
-                        !selectedUserId && !observationTime || selectedAnnotationSets.length === 0 || newAnnotationSetId === ''
+                        !selectedUserId && !observationTime || selectedAnnotationSets.length === 0 || (existingAnnotationSetId === '' && !moveToNewAnnotationSet)
                     }
                 >
                     Move Observations

--- a/src/MoveObservations.tsx
+++ b/src/MoveObservations.tsx
@@ -6,6 +6,7 @@ import { fetchAllPaginatedResults } from "./utils";
 import { useUpdateProgress } from './useUpdateProgress';
 import LabeledToggleSwitch from './LabeledToggleSwitch';
 import { MultiLocationSetDropdown } from './MultiLocationSetDropdown';
+import { useRetry } from './useRetry';
 
 type MoveObservationsProps = {
     show: boolean;
@@ -39,6 +40,7 @@ export default function MoveObservations({ show, handleClose, selectedAnnotation
     const [filterByUser, setFilterByUser] = useState<boolean>(true);
     const [selectedLocationSets, setSelectedLocationSets] = useState<string[]>([]);
     const [moveToNewAnnotationSet, setMoveToNewAnnotationSet] = useState<boolean>(true);
+    const { executeWithRetry } = useRetry();
 
     const handleMove = async () => {
         if (!moveToNewAnnotationSet && selectedAnnotationSets.includes(existingAnnotationSetId)) {
@@ -108,10 +110,11 @@ export default function MoveObservations({ show, handleClose, selectedAnnotation
             setObservationsUpdated(0);
             setTotalObservationsUpdated(filteredObservations.length);
             for (const observation of filteredObservations) {
-                await client.models.Observation.update({
+                await executeWithRetry(() => 
+                    client.models.Observation.update({
                     id: observation.id,
                     annotationSetId: targetAnnotationSetId
-                });
+                }))
 
                 setObservationsUpdated(prev => prev + 1);
             }

--- a/src/MultiLocationSetDropdown.tsx
+++ b/src/MultiLocationSetDropdown.tsx
@@ -1,0 +1,56 @@
+import { Form } from "react-bootstrap";
+import { useContext } from "react";
+import { ManagementContext } from "./Context";
+import Select, { MultiValue, Options } from "react-select";
+
+interface MultiLocationSetDropdownProps {
+  setLocationSets: (selected: string[]) => void;
+  selectedSets: string[] | undefined;
+  canCreate?: boolean;
+}
+
+interface OptionType {
+  label: string;
+  value: string;
+}
+
+export function MultiLocationSetDropdown({
+  setLocationSets,
+  selectedSets,
+}: MultiLocationSetDropdownProps) {
+  const {
+    locationSetsHook: { data: locationSets },
+  } = useContext(ManagementContext)!;
+
+  const options: Options<OptionType> | undefined = locationSets
+    ?.map((x) => ({
+      label: x.name,
+      value: x.id,
+    }))
+    .sort((a, b) => (a.label > b.label ? 1 : -1));
+
+  const selectedOptions = options?.filter((o) =>
+    selectedSets?.includes(o.value)
+  );
+
+  function handleChange(selectedOptions: MultiValue<OptionType>) {
+    const selectedValues = selectedOptions.map((o) => o.value);
+    setLocationSets(selectedValues);
+  }
+
+  return (
+    <Form.Group>
+      <Select
+        value={selectedOptions}
+        onChange={handleChange}
+        isMulti
+        name="Location Sets"
+        options={options}
+        className="basic-multi-select"
+        classNamePrefix="select"
+        closeMenuOnSelect={false}
+        placeholder="Select location sets..."
+      />
+    </Form.Group>
+  );
+}

--- a/src/useRetry.ts
+++ b/src/useRetry.ts
@@ -1,0 +1,50 @@
+interface RetryConfig {
+    maxRetries?: number;
+    baseDelay?: number;
+    maxDelay?: number;
+}
+
+export function useRetry(defaultConfig: RetryConfig = {}) {
+    const executeWithRetry = async <T>(
+        operation: () => Promise<T>,
+        config: RetryConfig = {}
+    ): Promise<T> => {
+        const {
+            maxRetries = 5,
+            baseDelay = 1000,
+            maxDelay = 30000
+        } = { ...defaultConfig, ...config };
+
+        let retryCount = 0;
+
+        while (retryCount < maxRetries) {
+            try {
+                const result = await operation();
+                
+                // Handle GraphQL-style responses that might contain errors
+                if (result && (result as any).errors) {
+                    throw new Error('Operation returned errors');
+                }
+                
+                return result;
+            } catch (error) {
+                retryCount++;
+                if (retryCount === maxRetries) {
+                    console.error(`Operation failed after ${maxRetries} attempts:`, error);
+                    throw error;
+                }
+                
+                const delay = Math.min(
+                    baseDelay * Math.pow(2, retryCount) + Math.random() * 1000,
+                    maxDelay
+                );
+                console.warn(`Retry ${retryCount}/${maxRetries} after ${delay}ms`);
+                await new Promise(resolve => setTimeout(resolve, delay));
+            }
+        }
+
+        throw new Error('Unexpected end of retry loop');
+    };
+
+    return { executeWithRetry };
+}


### PR DESCRIPTION
- Improved "move observations" logic
- Added useRetry hook that retries updates with exponential backoff. Long running tasks would fail because the access token is refreshed and this would cause a single query out of thousands to throw an auth error, stopping execution.
- Implemented the same logic in fetchPaginatedResults