### PR TITLE
Refactor distance calculation and update statistical significance level

### DIFF
--- a/src/JollyResults.tsx
+++ b/src/JollyResults.tsx
@@ -9,6 +9,7 @@ import DensityMap from './DensityMap.tsx';
 import exportFromJSON from 'export-from-json';
 import { useUsers } from './apiInterface';
 import { X, Clipboard } from 'lucide-react';
+// @ts-ignore
 import * as jStat from 'jstat';
 
 export default function JollyResults() {
@@ -440,5 +441,5 @@ export default function JollyResults() {
 function getTValue(n: number): number {
   const df = n - 1;
   if (df <= 0) return NaN;
-  return jStat.studentt.inv(0.975, df);
+  return jStat.studentt.inv(0.95, df);
 }


### PR DESCRIPTION
- Replaced Haversine distance function with a more accurate Vincenty distance calculation in generateSurveyResults handler.
- Adjusted t-value calculation in JollyResults to use a 0.95 confidence level instead of 0.975.