### PR TITLE
fix: prevent duplicate queue creation from client retry logic

### DIFF
--- a/amplify/functions/launchAnnotationSet/handler.ts
+++ b/amplify/functions/launchAnnotationSet/handler.ts
@@ -58,8 +58,8 @@ const createTasksOnAnnotationSetMutation = /* GraphQL */ `
 `;
 
 const updateProjectMutation = /* GraphQL */ `
-  mutation UpdateProject($input: UpdateProjectInput!) {
-    updateProject(input: $input) { id group }
+  mutation UpdateProject($input: UpdateProjectInput!, $condition: ModelProjectConditionInput) {
+    updateProject(input: $input, condition: $condition) { id group }
   }
 `;
 
@@ -144,6 +144,14 @@ const locationsBySetIdAndConfidence = /* GraphQL */ `
         id
       }
       nextToken
+    }
+  }
+`;
+
+const queuesByProjectIdQuery = /* GraphQL */ `
+  query QueuesByProjectId($projectId: ID!, $limit: Int) {
+    queuesByProjectId(projectId: $projectId, limit: $limit) {
+      items { id }
     }
   }
 `;
@@ -367,11 +375,33 @@ export const handler: LaunchAnnotationSetHandler = async (event) => {
 
     authorizeRequest(event.identity, organizationId);
 
-    // Use 'processing' for tiling-only, 'launching' for actual annotation set launches
-    await setProjectStatus(
-      payload.projectId,
-      isTilingOnly ? 'processing' : 'launching'
-    );
+    // Use 'processing' for tiling-only, 'launching' for actual annotation set launches.
+    // Conditional update: only proceed if the project is currently 'active'.
+    // This acts as an atomic lock — if two launches race, only one wins.
+    try {
+      await setProjectStatus(
+        payload.projectId,
+        isTilingOnly ? 'processing' : 'launching',
+        { status: { eq: 'active' } }
+      );
+    } catch (err: any) {
+      const msg = err?.message ?? '';
+      const errMsgs = Array.isArray(err?.errors)
+        ? err.errors.map((e: any) => e?.message ?? '').join(' ')
+        : '';
+      if (msg.includes('ConditionalCheckFailed') || errMsgs.includes('ConditionalCheckFailed')) {
+        console.warn('Launch rejected: project is not in active status', {
+          projectId: payload.projectId,
+        });
+        return {
+          statusCode: 200,
+          body: JSON.stringify({
+            message: 'Project is already launching or processing',
+          }),
+        };
+      }
+      throw err;
+    }
 
     await executeGraphql<{ updateProjectMemberships?: string | null }>(
       updateProjectMembershipsMutation,
@@ -430,6 +460,21 @@ async function handleLaunch(payload: LaunchLambdaPayload, organizationId: string
 
   if (!locationIds || locationIds.length === 0) {
     throw new Error('No locations provided to launch');
+  }
+
+  // Guard: prevent duplicate queues for the same project and tag
+  const existingQueue = await findExistingQueue(payload.projectId);
+  if (existingQueue) {
+    console.warn('Duplicate queue launch blocked', {
+      projectId: payload.projectId,
+      existingQueueId: existingQueue.id,
+    });
+    await setProjectStatus(payload.projectId, 'active');
+    return {
+      message: 'A queue already exists for this project',
+      locationCount: 0,
+      queueId: existingQueue.id,
+    };
   }
 
   console.log('Creating queues', {
@@ -1070,6 +1115,22 @@ async function createQueue(
   };
 }
 
+// Check if any queue already exists for this project.
+async function findExistingQueue(
+  projectId: string
+): Promise<{ id: string } | null> {
+  const data = await executeGraphql<{
+    queuesByProjectId?: {
+      items: Array<{ id: string }>;
+    };
+  }>(queuesByProjectIdQuery, {
+    projectId,
+    limit: 1,
+  });
+  const first = data.queuesByProjectId?.items?.[0];
+  return first ? { id: first.id } : null;
+}
+
 // writeLocationManifest removed - now handled by client or tiling task monitor
 
 // Batch SQS writes so we stay within SDK limits.
@@ -1191,7 +1252,11 @@ function makeSafeQueueName(input: string): string {
 }
 
 // Flip project status in AppSync so the UI reflects progress.
-async function setProjectStatus(projectId: string, status: string) {
+async function setProjectStatus(
+  projectId: string,
+  status: string,
+  condition?: { status: { eq: string } }
+) {
   await executeGraphql<{ updateProject?: { id: string } }>(
     updateProjectMutation,
     {
@@ -1199,6 +1264,7 @@ async function setProjectStatus(projectId: string, status: string) {
         id: projectId,
         status,
       },
+      ...(condition ? { condition } : {}),
     }
   );
 }

--- a/amplify/functions/launchFalseNegatives/handler.ts
+++ b/amplify/functions/launchFalseNegatives/handler.ts
@@ -64,8 +64,8 @@ const createTasksOnAnnotationSetMutation = /* GraphQL */ `
 `;
 
 const updateProjectMutation = /* GraphQL */ `
-  mutation UpdateProject($input: UpdateProjectInput!) {
-    updateProject(input: $input) { id group }
+  mutation UpdateProject($input: UpdateProjectInput!, $condition: ModelProjectConditionInput) {
+    updateProject(input: $input, condition: $condition) { id group }
   }
 `;
 
@@ -84,6 +84,14 @@ const createTilingTaskMutation = /* GraphQL */ `
 const createTilingBatchMutation = /* GraphQL */ `
   mutation CreateTilingBatch($input: CreateTilingBatchInput!) {
     createTilingBatch(input: $input) { id group }
+  }
+`;
+
+const queuesByProjectIdQuery = /* GraphQL */ `
+  query QueuesByProjectId($projectId: ID!, $limit: Int) {
+    queuesByProjectId(projectId: $projectId, limit: $limit) {
+      items { id }
+    }
   }
 `;
 
@@ -300,7 +308,30 @@ export const handler: LaunchFalseNegativesHandler = async (event) => {
 
     authorizeRequest(event.identity, organizationId);
 
-    await setProjectStatus(payload.projectId, 'launching');
+    // Conditional update: only proceed if the project is currently 'active'.
+    try {
+      await setProjectStatus(payload.projectId, 'launching', {
+        status: { eq: 'active' },
+      });
+    } catch (err: any) {
+      const msg = err?.message ?? '';
+      const errMsgs = Array.isArray(err?.errors)
+        ? err.errors.map((e: any) => e?.message ?? '').join(' ')
+        : '';
+      if (msg.includes('ConditionalCheckFailed') || errMsgs.includes('ConditionalCheckFailed')) {
+        console.warn('Launch rejected: project is not in active status', {
+          projectId: payload.projectId,
+        });
+        return {
+          statusCode: 200,
+          body: JSON.stringify({
+            message: 'Project is already launching or processing',
+          }),
+        };
+      }
+      throw err;
+    }
+
     await executeGraphql<{ updateProjectMemberships?: string | null }>(
       updateProjectMembershipsMutation,
       { projectId: payload.projectId }
@@ -601,6 +632,21 @@ async function handleLaunch(payload: LaunchFalseNegativesPayload, organizationId
       message: 'No candidate tiles discovered',
       locationCount: 0,
       queueId: null,
+    };
+  }
+
+  // Guard: prevent duplicate queues for the same project and tag
+  const existingQueue = await findExistingQueue(projectId);
+  if (existingQueue) {
+    console.warn('Duplicate queue launch blocked', {
+      projectId,
+      existingQueueId: existingQueue.id,
+    });
+    await setProjectStatus(projectId, 'active');
+    return {
+      message: 'A queue already exists for this project',
+      locationCount: 0,
+      queueId: existingQueue.id,
     };
   }
 
@@ -1522,6 +1568,22 @@ async function createQueue(
   return { id: createdQueue.id, url: queueUrl };
 }
 
+// Check if any queue already exists for this project.
+async function findExistingQueue(
+  projectId: string
+): Promise<{ id: string } | null> {
+  const data = await executeGraphql<{
+    queuesByProjectId?: {
+      items: Array<{ id: string }>;
+    };
+  }>(queuesByProjectIdQuery, {
+    projectId,
+    limit: 1,
+  });
+  const first = data.queuesByProjectId?.items?.[0];
+  return first ? { id: first.id } : null;
+}
+
 // Fan selected tiles into SQS batches respecting FIFO rules.
 async function enqueueTiles(
   queueUrl: string,
@@ -1780,13 +1842,18 @@ function makeSafeQueueName(input: string): string {
 }
 
 // Persist project status transitions for UI feedback.
-async function setProjectStatus(projectId: string, status: string) {
+async function setProjectStatus(
+  projectId: string,
+  status: string,
+  condition?: { status: { eq: string } }
+) {
   await withTiming(`setProjectStatus:${status}`, () =>
     executeGraphql<{ updateProject?: { id: string } }>(updateProjectMutation, {
       input: {
         id: projectId,
         status,
       },
+      ...(condition ? { condition } : {}),
     })
   );
 }

--- a/amplify/functions/launchQCReview/handler.ts
+++ b/amplify/functions/launchQCReview/handler.ts
@@ -26,8 +26,8 @@ const createQueueMutation = /* GraphQL */ `
 `;
 
 const updateProjectMutation = /* GraphQL */ `
-  mutation UpdateProject($input: UpdateProjectInput!) {
-    updateProject(input: $input) { id group }
+  mutation UpdateProject($input: UpdateProjectInput!, $condition: ModelProjectConditionInput) {
+    updateProject(input: $input, condition: $condition) { id group }
   }
 `;
 
@@ -40,6 +40,14 @@ const updateProjectMembershipsMutation = /* GraphQL */ `
 const getProjectOrganizationId = /* GraphQL */ `
   query GetProject($id: ID!) {
     getProject(id: $id) { organizationId }
+  }
+`;
+
+const queuesByProjectIdQuery = /* GraphQL */ `
+  query QueuesByProjectId($projectId: ID!, $limit: Int) {
+    queuesByProjectId(projectId: $projectId, limit: $limit) {
+      items { id }
+    }
   }
 `;
 
@@ -184,7 +192,29 @@ export const handler: LaunchQCReviewHandler = async (event) => {
 
     authorizeRequest(event.identity, organizationId);
 
-    await setProjectStatus(payload.projectId, 'launching');
+    // Conditional update: only proceed if the project is currently 'active'.
+    try {
+      await setProjectStatus(payload.projectId, 'launching', {
+        status: { eq: 'active' },
+      });
+    } catch (err: any) {
+      const msg = err?.message ?? '';
+      const errMsgs = Array.isArray(err?.errors)
+        ? err.errors.map((e: any) => e?.message ?? '').join(' ')
+        : '';
+      if (msg.includes('ConditionalCheckFailed') || errMsgs.includes('ConditionalCheckFailed')) {
+        console.warn('Launch rejected: project is not in active status', {
+          projectId: payload.projectId,
+        });
+        return {
+          statusCode: 200,
+          body: JSON.stringify({
+            message: 'Project is already launching or processing',
+          }),
+        };
+      }
+      throw err;
+    }
 
     const result = await handleLaunch(payload, organizationId);
 
@@ -291,7 +321,24 @@ async function handleLaunch(payload: LaunchQCReviewPayload, organizationId: stri
   );
   console.log('Wrote QC manifest to S3', { manifestKey, itemCount: sampled.length });
 
-  // 6. Create the SQS queue and Queue record.
+  // 6. Guard: prevent duplicate queues for the same project.
+  const existingQueue = await findExistingQueue(projectId);
+  if (existingQueue) {
+    console.warn('Duplicate queue launch blocked', {
+      projectId,
+      existingQueueId: existingQueue.id,
+    });
+    await setProjectStatus(projectId, 'active');
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        message: 'A queue already exists for this project',
+        queueId: existingQueue.id,
+      }),
+    };
+  }
+
+  // 7. Create the SQS queue and Queue record.
   // `name` carries the category name (displayed as the heading on Jobs page).
   // `tag` stays 'qc-review' (used by requeue lambda for branching).
   const queueDisplayName = payload.categoryName || 'QC Review';
@@ -445,6 +492,22 @@ async function createQueue(
   return { id: createdQueue.id, url: queueUrl };
 }
 
+// Check if any queue already exists for this project.
+async function findExistingQueue(
+  projectId: string
+): Promise<{ id: string } | null> {
+  const data = await executeGraphql<{
+    queuesByProjectId?: {
+      items: Array<{ id: string }>;
+    };
+  }>(queuesByProjectIdQuery, {
+    projectId,
+    limit: 1,
+  });
+  const first = data.queuesByProjectId?.items?.[0];
+  return first ? { id: first.id } : null;
+}
+
 // ── SQS enqueueing ──
 
 async function enqueueAnnotations(
@@ -555,9 +618,14 @@ function makeSafeQueueName(input: string): string {
   return sanitized;
 }
 
-async function setProjectStatus(projectId: string, status: string) {
+async function setProjectStatus(
+  projectId: string,
+  status: string,
+  condition?: { status: { eq: string } }
+) {
   await executeGraphql<{ updateProject?: { id: string } }>(updateProjectMutation, {
     input: { id: projectId, status },
+    ...(condition ? { condition } : {}),
   });
 }
 

--- a/amplify/functions/monitorTilingTasks/handler.ts
+++ b/amplify/functions/monitorTilingTasks/handler.ts
@@ -66,6 +66,14 @@ const updateTilingTaskMutation = /* GraphQL */ `
   }
 `;
 
+const queuesByProjectIdQuery = /* GraphQL */ `
+  query QueuesByProjectId($projectId: ID!, $limit: Int) {
+    queuesByProjectId(projectId: $projectId, limit: $limit) {
+      items { id }
+    }
+  }
+`;
+
 // Configure Amplify for IAM-based GraphQL access.
 Amplify.configure(
   {
@@ -331,6 +339,20 @@ async function processTask(task: TilingTaskRecord) {
       }
     }
 
+    // Guard: prevent duplicate queues for the same project and tag
+    const existingQueue = await findExistingQueue(task.projectId);
+    if (existingQueue) {
+      console.warn('Duplicate queue launch blocked', {
+        projectId: task.projectId,
+        existingQueueId: existingQueue.id,
+        taskId: task.id,
+      });
+      await setProjectStatus(task.projectId, 'active');
+      await cleanupBatchOutputs(completedBatches);
+      await updateTaskCompleted(task.id);
+      return;
+    }
+
     // Create queue and enqueue locations
     const mainQueue = await createQueue(
       launchConfig.queueOptions,
@@ -539,6 +561,22 @@ async function cleanupBatchOutputs(batches: TilingBatchRecord[]): Promise<void> 
     );
 
   await Promise.all(deleteTasks);
+}
+
+// Check if any queue already exists for this project.
+async function findExistingQueue(
+  projectId: string
+): Promise<{ id: string } | null> {
+  const data = await executeGraphql<{
+    queuesByProjectId?: {
+      items: Array<{ id: string }>;
+    };
+  }>(queuesByProjectIdQuery, {
+    projectId,
+    limit: 1,
+  });
+  const first = data.queuesByProjectId?.items?.[0];
+  return first ? { id: first.id } : null;
 }
 
 async function createQueue(

--- a/src/limitedClient.ts
+++ b/src/limitedClient.ts
@@ -80,6 +80,12 @@ async function executeWithRetry<T>(
   throw new Error('Unexpected end of retry loop');
 }
 
+// Options that can be passed as the last argument to any wrapped client method.
+type ClientCallOptions = {
+  /** Set to false to skip retry logic (e.g. for long-running launch mutations). Defaults to true. */
+  retry?: boolean;
+};
+
 // Recursive function to wrap client methods with retry logic
 function wrapClientMethods(obj: any): any {
   if (typeof obj !== 'object' || obj === null) {
@@ -95,9 +101,20 @@ function wrapClientMethods(obj: any): any {
         wrappedObj[key] = value;
       } else {
         wrappedObj[key] = async (...args: any[]) => {
-          const result = await executeWithRetry(() =>
-            limit(() => value(...args))
-          );
+          // Check if the last argument is a ClientCallOptions object
+          const lastArg = args[args.length - 1];
+          const hasOptions =
+            lastArg &&
+            typeof lastArg === 'object' &&
+            'retry' in lastArg;
+          const options: ClientCallOptions = hasOptions ? args.pop() : {};
+          const shouldRetry = options.retry !== false;
+
+          const execute = () => limit(() => value(...args));
+
+          const result = shouldRetry
+            ? await executeWithRetry(execute)
+            : await execute();
           const checkedResult = checkForErrors(result);
           return wrapClientMethods(checkedResult);
         };

--- a/src/survey/FalseNegatives.tsx
+++ b/src/survey/FalseNegatives.tsx
@@ -1226,9 +1226,9 @@ async function sendLaunchFalseNegativesRequest(
   }
 
   try {
-    await client.mutations.launchFalseNegatives({
+    await (client as any).mutations.launchFalseNegatives({
       request: requestPayload,
-    });
+    }, { retry: false });
   } catch (error: any) {
     if (shouldIgnoreLaunchError(error)) {
       console.warn('Ignoring launch lambda timeout response', error);

--- a/src/survey/HomographyLaunch.tsx
+++ b/src/survey/HomographyLaunch.tsx
@@ -588,7 +588,7 @@ async function sendLaunchRequest(
 ) {
   const requestPayload = JSON.stringify(payload);
   try {
-    await (client as any).mutations.launchHomography({ request: requestPayload });
+    await (client as any).mutations.launchHomography({ request: requestPayload }, { retry: false });
   } catch (error: any) {
     if (shouldIgnoreLaunchError(error)) {
       console.warn('Ignoring launch lambda timeout response', error);

--- a/src/survey/LaunchAnnotationSetModal.tsx
+++ b/src/survey/LaunchAnnotationSetModal.tsx
@@ -71,45 +71,38 @@ export default function LaunchAnnotationSetModal({
 
   async function handleSubmit() {
     const originalStatus = project.status ?? 'active';
-    let optimisticStatusApplied = false;
     setLaunching(true);
+
+    // Set optimistic status immediately so the project is blocked for the
+    // user even before the modal closes, preventing rapid re-launches.
+    if (taskType !== 'registration') {
+      onOptimisticStatus?.(project.id, 'launching');
+    }
 
     try {
       switch (taskType) {
         case 'species-labelling':
           if (speciesLaunchHandler) {
             setProgressMessage('Initializing launch...');
-            await speciesLaunchHandler.execute(setProgressMessage, () => {
-              onOptimisticStatus?.(project.id, 'launching');
-              optimisticStatusApplied = true;
-            });
+            await speciesLaunchHandler.execute(setProgressMessage, () => {});
           }
           break;
         case 'false-negatives':
           if (falseNegativesLaunchHandler) {
             setProgressMessage('Initializing launch...');
-            await falseNegativesLaunchHandler.execute(setProgressMessage, () => {
-              onOptimisticStatus?.(project.id, 'launching');
-              optimisticStatusApplied = true;
-            });
+            await falseNegativesLaunchHandler.execute(setProgressMessage, () => {});
           }
           break;
         case 'qc-review':
           if (qcLaunchHandler) {
             setProgressMessage('Initializing launch...');
-            await qcLaunchHandler.execute(setProgressMessage, () => {
-              onOptimisticStatus?.(project.id, 'launching');
-              optimisticStatusApplied = true;
-            });
+            await qcLaunchHandler.execute(setProgressMessage, () => {});
           }
           break;
         case 'homographies':
           if (homographyLaunchHandler) {
             setProgressMessage('Initializing launch...');
-            await homographyLaunchHandler.execute(setProgressMessage, () => {
-              onOptimisticStatus?.(project.id, 'launching');
-              optimisticStatusApplied = true;
-            });
+            await homographyLaunchHandler.execute(setProgressMessage, () => {});
           }
           break;
         case 'registration':
@@ -118,9 +111,7 @@ export default function LaunchAnnotationSetModal({
       }
     } catch (error) {
       console.error('Launch error', error);
-      if (optimisticStatusApplied) {
-        onOptimisticStatus?.(project.id, originalStatus);
-      }
+      onOptimisticStatus?.(project.id, originalStatus);
       throw error;
     } finally {
       setLaunching(false);

--- a/src/survey/ProcessImages.tsx
+++ b/src/survey/ProcessImages.tsx
@@ -158,13 +158,13 @@ export default function ProcessImages({ projectId, organizationId }: { projectId
             (image) => `${image.id}---${makeKey(image.originalPath)}`
           );
 
-          client.mutations.runScoutbot({
+          (client as any).mutations.runScoutbot({
             projectId: projectId,
             images: batchStrings,
             setId: locationSet.id,
             bucket: backend.storage.buckets[1].bucket_name,
             queueUrl: backend.custom.scoutbotTaskQueueUrl,
-          });
+          }, { retry: false });
 
           await client.models.Project.update({
             id: projectId,
@@ -179,10 +179,10 @@ export default function ProcessImages({ projectId, organizationId }: { projectId
             makeKey(image.originalPath)
           );
 
-          client.mutations.runHeatmapper({
+          (client as any).mutations.runHeatmapper({
             projectId,
             images: batchStrings,
-          });
+          }, { retry: false });
         }
 
         await client.models.Project.update({
@@ -197,13 +197,13 @@ export default function ProcessImages({ projectId, organizationId }: { projectId
             (image) => `${image.id}---${makeKey(image.originalPath)}`
           );
 
-          client.mutations.runMadDetector({
+          (client as any).mutations.runMadDetector({
             projectId: projectId,
             images: batchStrings,
             setId: locationSet.id,
             bucket: backend.storage.buckets[1].bucket_name,
             queueUrl: backend.custom.madDetectorTaskQueueUrl,
-          });
+          }, { retry: false });
 
           await client.models.Project.update({
             id: projectId,

--- a/src/survey/QCReview.tsx
+++ b/src/survey/QCReview.tsx
@@ -533,7 +533,7 @@ async function sendLaunchQCReviewRequest(
   try {
     await (client as any).mutations.launchQCReview({
       request: requestPayload,
-    });
+    }, { retry: false });
   } catch (error: any) {
     // Ignore timeout errors - the Lambda may still be processing.
     if (shouldIgnoreLaunchError(error)) {

--- a/src/survey/Surveys.tsx
+++ b/src/survey/Surveys.tsx
@@ -251,7 +251,7 @@ export default function Surveys() {
       project?.organizationId || ''
     );
 
-    client.mutations.deleteProjectInFull({ projectId: projectId });
+    (client as any).mutations.deleteProjectInFull({ projectId: projectId }, { retry: false });
   }
 
   async function deleteAnnotationSet(

--- a/src/upload/UploadManager.tsx
+++ b/src/upload/UploadManager.tsx
@@ -912,14 +912,14 @@ export default function UploadManager() {
           cameraId: img.cameraId,
         }));
 
-        client.mutations.runImageRegistration({
+        (client as any).mutations.runImageRegistration({
           projectId: projectId,
           metadata: JSON.stringify({
             masks: masks,
             images: payload,
           }),
           queueUrl: backend.custom.lightglueTaskQueueUrl,
-        });
+        }, { retry: false });
       }
 
       if (model === 'manual') {
@@ -976,13 +976,13 @@ export default function UploadManager() {
             (image) => `${image.id}---${makeKey(image.originalPath)}`
           );
 
-          client.mutations.runScoutbot({
+          (client as any).mutations.runScoutbot({
             projectId: projectId,
             images: batchStrings,
             setId: locationSet,
             bucket: backend.storage.buckets[1].bucket_name,
             queueUrl: backend.custom.scoutbotTaskQueueUrl,
-          });
+          }, { retry: false });
         }
 
         await client.models.Project.update({
@@ -998,10 +998,10 @@ export default function UploadManager() {
             makeKey(image.originalPath)
           );
 
-          client.mutations.runHeatmapper({
+          (client as any).mutations.runHeatmapper({
             projectId,
             images: batchStrings,
-          });
+          }, { retry: false });
         }
 
         await client.models.Project.update({
@@ -1056,13 +1056,13 @@ export default function UploadManager() {
             (image) => `${image.id}---${makeKey(image.originalPath)}`
           );
 
-          client.mutations.runMadDetector({
+          (client as any).mutations.runMadDetector({
             projectId: projectId,
             images: batchStrings,
             setId: locationSet,
             bucket: backend.storage.buckets[1].bucket_name,
             queueUrl: backend.custom.madDetectorTaskQueueUrl,
-          });
+          }, { retry: false });
         }
 
         await client.models.Project.update({

--- a/src/useLaunchTask.ts
+++ b/src/useLaunchTask.ts
@@ -391,9 +391,9 @@ async function sendLaunchLambdaRequest(
   }
 
   try {
-    await client.mutations.launchAnnotationSet({
+    await (client as any).mutations.launchAnnotationSet({
       request: requestPayload,
-    });
+    }, { retry: false });
   } catch (error: any) {
     if (shouldIgnoreLaunchError(error)) {
       console.warn('Ignoring launch lambda timeout response', error);


### PR DESCRIPTION
The limitedClient wraps all mutations with executeWithRetry (4 retries, exponential backoff). Long-running launch Lambdas (~32s) would timeout from AppSync's perspective, triggering client retries that each created a new queue - producing up to 4 duplicates per launch.

Frontend:
- Set optimistic project status to 'launching' immediately on submit in LaunchAnnotationSetModal, blocking re-launches before modal closes
- Add { retry: false } option to limitedClient wrapper - skips executeWithRetry while preserving pLimit concurrency limiting
- Apply { retry: false } to all launch mutations (launchAnnotationSet, launchQCReview, launchFalseNegatives, launchHomography), ML processing mutations (runScoutbot, runHeatmapper, runMadDetector, runImageRegistration), and deleteProjectInFull

Backend:
- Add conditional DynamoDB update on setProjectStatus('launching') in launchAnnotationSet, launchQCReview, and launchFalseNegatives - only succeeds if project status is currently 'active', acting as an atomic lock against concurrent Lambda invocations
- Add findExistingQueue(projectId) guard in all four launchers (launchAnnotationSet, launchQCReview, launchFalseNegatives, monitorTilingTasks) - rejects launch if any queue exists for the project