### PR TITLE
feat: add on-demand slippy map tile generation

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -5,6 +5,7 @@ import { addUserToGroup } from './functions/add-user-to-group/resource';
 import { Stack, Fn } from 'aws-cdk-lib';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { outputBucket, inputBucket } from './storage/resource';
+import { generateTile } from './storage/generateTile/resource';
 import { handleS3Upload } from './storage/handleS3Upload/resource';
 //import * as sts from '@aws-sdk/client-sts';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
@@ -54,6 +55,7 @@ const backend = defineBackend({
   addUserToGroup,
   outputBucket,
   inputBucket,
+  generateTile,
   handleS3Upload,
   processImages,
   postDeploy,
@@ -276,11 +278,10 @@ Object.values(backend.auth.resources.groups).forEach(({ role }) => {
 backend.auth.resources.groups['sysadmin'].role.addToPrincipalPolicy(sqsSysadminStatement);
 backend.auth.resources.groups['sysadmin'].role.addToPrincipalPolicy(groupEcsListPolicy);
 
-// Add the Sharp layer and throttle concurrency on the image upload Lambda.
-const lambdaFunction = backend.handleS3Upload.resources
-  .lambda as lambda.Function;
-const layerVersion = new lambda.LayerVersion(
-  Stack.of(lambdaFunction),
+// Add the Sharp layer to the on-demand tile generation Lambda.
+const generateTileLambda = backend.generateTile.resources.lambda as lambda.Function;
+const sharpLayer = new lambda.LayerVersion(
+  Stack.of(generateTileLambda),
   'sharpLayer',
   {
     code: lambda.Code.fromAsset('./amplify/layers/sharp-ph200-x64'),
@@ -288,7 +289,12 @@ const layerVersion = new lambda.LayerVersion(
     compatibleArchitectures: [lambda.Architecture.X86_64],
   }
 );
-lambdaFunction.addLayers(layerVersion);
+generateTileLambda.addLayers(sharpLayer);
+
+// Also attach the Sharp layer to the eager on-upload tiler, and throttle
+// its concurrency so a bulk upload doesn't spawn thousands of parallel invocations.
+const handleS3UploadLambda = backend.handleS3Upload.resources.lambda as lambda.Function;
+handleS3UploadLambda.addLayers(sharpLayer);
 backend.handleS3Upload.resources.cfnResources.cfnFunction.addPropertyOverride(
   'ReservedConcurrentExecutions',
   50

--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -35,6 +35,7 @@ import { updateActiveOrganizations } from '../functions/updateActiveOrganization
 import { launchQCReview } from '../functions/launchQCReview/resource';
 import { launchHomography } from '../functions/launchHomography/resource';
 import { reconcileHomographies } from '../functions/reconcileHomographies/resource';
+import { generateTile } from '../storage/generateTile/resource';
 // import { consolidateUserStats } from '../functions/consolidateUserStats/resource';
 
 const schema = a
@@ -1172,6 +1173,17 @@ const schema = a
       .returns(a.json())
       .authorization((allow) => [allow.authenticated()])
       .handler(a.handler.function(updateActiveOrganizations)),
+    generateTile: a
+      .query()
+      .arguments({
+        imageKey: a.string().required(),
+        zs: a.integer().required().array().required(),
+        rows: a.integer().required().array().required(),
+        cols: a.integer().required().array().required(),
+      })
+      .returns(a.string().array())
+      .authorization((allow) => [allow.authenticated()])
+      .handler(a.handler.function(generateTile)),
     // Dummy table used to force full deployment instead of hotswapping resources
     fixDeploymentTable: a
       .model({

--- a/amplify/storage/generateTile/handler.mjs
+++ b/amplify/storage/generateTile/handler.mjs
@@ -1,0 +1,291 @@
+import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import sharp from 'sharp';
+import { env } from '$amplify/env/generateTile';
+
+const s3 = new S3Client();
+
+// LRU source cache kept in module scope. Warm invocations that target a
+// recently-seen image skip both the S3 fetch and the JPEG decode. Size 3
+// fits comfortably under the 2GB Lambda memory limit (each raw buffer for
+// a 60MP RGB image is ~180MB; observed peak with 1-entry was 620MB).
+const SOURCE_CACHE_CAPACITY = 3;
+const sourceCache = new Map(); // imageKey -> { raw, info: { width, height, channels } }
+
+function sourceCacheGet(imageKey) {
+  const entry = sourceCache.get(imageKey);
+  if (!entry) return null;
+  // Re-insert to mark as most-recently-used (Map preserves insertion order).
+  sourceCache.delete(imageKey);
+  sourceCache.set(imageKey, entry);
+  return entry;
+}
+
+function sourceCacheSet(imageKey, entry) {
+  if (sourceCache.has(imageKey)) {
+    sourceCache.delete(imageKey);
+  } else if (sourceCache.size >= SOURCE_CACHE_CAPACITY) {
+    const oldestKey = sourceCache.keys().next().value;
+    sourceCache.delete(oldestKey);
+  }
+  sourceCache.set(imageKey, entry);
+}
+
+function getMaxZoom(width, height) {
+  return Math.ceil(Math.log2(Math.max(width, height) / 256));
+}
+
+async function streamToBuffer(stream) {
+  const chunks = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+async function fetchSourceBytes(imageKey) {
+  const response = await s3.send(
+    new GetObjectCommand({
+      Bucket: env.INPUTS_BUCKET_NAME,
+      Key: imageKey,
+    })
+  );
+  return streamToBuffer(response.Body);
+}
+
+async function getSource(imageKey, timings) {
+  const cached = sourceCacheGet(imageKey);
+  if (cached) {
+    timings.cacheHit = true;
+    timings.cacheSize = sourceCache.size;
+    return cached;
+  }
+  timings.cacheHit = false;
+
+  const fetchStart = performance.now();
+  const imageBuffer = await fetchSourceBytes(imageKey);
+  timings.fetchSourceMs = performance.now() - fetchStart;
+  timings.sourceBytes = imageBuffer.length;
+
+  const decodeStart = performance.now();
+  const { data, info } = await sharp(imageBuffer)
+    .rotate()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  timings.decodeMs = performance.now() - decodeStart;
+  timings.rawBytes = data.length;
+
+  const entry = { raw: data, info };
+  sourceCacheSet(imageKey, entry);
+  timings.cacheSize = sourceCache.size;
+  return entry;
+}
+
+async function fetchTileFromS3(outputKey) {
+  try {
+    const response = await s3.send(
+      new GetObjectCommand({
+        Bucket: env.OUTPUTS_BUCKET_NAME,
+        Key: outputKey,
+      })
+    );
+    return await streamToBuffer(response.Body);
+  } catch (err) {
+    if (
+      err?.name === 'NoSuchKey' ||
+      err?.Code === 'NoSuchKey' ||
+      err?.$metadata?.httpStatusCode === 404
+    ) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+async function generateSingleTile(source, z, row, col) {
+  const { raw, info } = source;
+  const { width, height, channels } = info;
+  const maxZ = getMaxZoom(width, height);
+
+  if (z > maxZ) return null;
+
+  const tilePixels = 256 * Math.pow(2, maxZ - z);
+  const x0 = col * tilePixels;
+  const y0 = row * tilePixels;
+
+  if (x0 >= width || y0 >= height) return null;
+
+  const extractW = Math.min(tilePixels, width - x0);
+  const extractH = Math.min(tilePixels, height - y0);
+  const outW = Math.max(1, Math.round((256 * extractW) / tilePixels));
+  const outH = Math.max(1, Math.round((256 * extractH) / tilePixels));
+
+  let pipeline = sharp(raw, { raw: { width, height, channels } })
+    .extract({ left: x0, top: y0, width: extractW, height: extractH })
+    .resize(outW, outH);
+
+  if (outW < 256 || outH < 256) {
+    pipeline = pipeline.extend({
+      right: 256 - outW,
+      bottom: 256 - outH,
+      background: { r: 0, g: 0, b: 0, alpha: 0 },
+    });
+  }
+
+  return pipeline.png().toBuffer();
+}
+
+async function uploadTile(tileBuffer, outputKey) {
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: env.OUTPUTS_BUCKET_NAME,
+      Key: outputKey,
+      Body: tileBuffer,
+      ContentType: 'image/png',
+    })
+  );
+}
+
+/**
+ * AppSync query handler.
+ *
+ * Arguments:
+ *   imageKey - the source image key (e.g. 'images/orgId/projectId/image.jpg')
+ *   zs       - array of zoom levels
+ *   rows     - array of tile rows
+ *   cols     - array of tile columns
+ *
+ * Returns an array of base64-encoded PNG tile data, one per input tile, in
+ * the same order. Empty string for tiles outside the image bounds.
+ *
+ * Strategy (hybrid):
+ *   1. Check S3 outputs bucket for each requested tile in parallel.
+ *   2. For tiles that miss, decode the source image once (cached across
+ *      invocations in module scope) and generate each missing tile from raw.
+ *   3. Upload the newly-generated tiles back to S3 so subsequent requests —
+ *      including from other Lambda containers / other users — can serve
+ *      them cheaply.
+ */
+export async function handler(event) {
+  const { imageKey, zs, rows, cols } = event.arguments;
+
+  if (!imageKey || !zs || !rows || !cols) {
+    throw new Error('Missing required parameters: imageKey, zs, rows, cols');
+  }
+  if (zs.length !== rows.length || zs.length !== cols.length) {
+    throw new Error('zs, rows, cols must all be the same length');
+  }
+  if (zs.length === 0) {
+    return [];
+  }
+  for (let i = 0; i < zs.length; i++) {
+    if (zs[i] == null || rows[i] == null || cols[i] == null) {
+      throw new Error(`Null tile coordinate at index ${i}`);
+    }
+  }
+
+  const timings = {
+    tileCount: zs.length,
+    s3HitCount: 0,
+    s3MissCount: 0,
+    s3CheckMs: 0,
+    cacheHit: false,
+    fetchSourceMs: 0,
+    sourceBytes: 0,
+    decodeMs: 0,
+    rawBytes: 0,
+    tileWorkMs: 0,
+    uploadTilesMs: 0,
+  };
+  const totalStart = performance.now();
+
+  try {
+    const sourceKey = imageKey.replace(/^images\//, '');
+    const outputKeys = zs.map(
+      (z, i) => `slippymaps/${sourceKey}/${z}/${rows[i]}/${cols[i]}.png`
+    );
+
+    // Step 1: probe S3 for every requested tile in parallel.
+    const s3CheckStart = performance.now();
+    const tileBuffers = await Promise.all(outputKeys.map(fetchTileFromS3));
+    timings.s3CheckMs = performance.now() - s3CheckStart;
+
+    const missingIndices = [];
+    tileBuffers.forEach((buf, i) => {
+      if (!buf) missingIndices.push(i);
+    });
+    timings.s3HitCount = zs.length - missingIndices.length;
+    timings.s3MissCount = missingIndices.length;
+
+    // Step 2: generate only the tiles that weren't already on S3.
+    if (missingIndices.length > 0) {
+      const source = await getSource(imageKey, timings);
+      timings.imageWidth = source.info.width;
+      timings.imageHeight = source.info.height;
+      timings.maxZ = getMaxZoom(source.info.width, source.info.height);
+
+      const tileWorkStart = performance.now();
+      const generated = await Promise.all(
+        missingIndices.map((i) =>
+          generateSingleTile(source, zs[i], rows[i], cols[i])
+        )
+      );
+      timings.tileWorkMs = performance.now() - tileWorkStart;
+
+      // Step 3: upload the new tiles (in parallel) and slot them into the result.
+      // Upload failures are logged but do not fail the request — the generated
+      // tile data is still returned to the caller; only the S3 write-back is lost.
+      const uploadStart = performance.now();
+      let uploadFailures = 0;
+      await Promise.all(
+        generated.map((buf, j) => {
+          const i = missingIndices[j];
+          tileBuffers[i] = buf;
+          if (!buf) return null;
+          return uploadTile(buf, outputKeys[i]).catch((e) => {
+            uploadFailures++;
+            console.log(
+              JSON.stringify({
+                msg: 'tile_upload_failed',
+                key: outputKeys[i],
+                error: e.message,
+              })
+            );
+          });
+        })
+      );
+      timings.uploadTilesMs = performance.now() - uploadStart;
+      timings.uploadFailures = uploadFailures;
+    }
+
+    const result = tileBuffers.map((buf) => (buf ? buf.toString('base64') : ''));
+
+    timings.tileBytes = tileBuffers.reduce(
+      (sum, b) => sum + (b ? b.length : 0),
+      0
+    );
+    timings.totalMs = performance.now() - totalStart;
+    timings.msPerTile = timings.totalMs / zs.length;
+
+    console.log(
+      JSON.stringify({
+        msg: 'tiles_generated',
+        imageKey,
+        tiles: zs.map((z, i) => `${z}/${rows[i]}/${cols[i]}`),
+        ...timings,
+      })
+    );
+
+    return result;
+  } catch (err) {
+    timings.totalMs = performance.now() - totalStart;
+    console.log(
+      JSON.stringify({
+        msg: 'tiles_failed',
+        imageKey,
+        error: err.message,
+        ...timings,
+      })
+    );
+    throw err;
+  }
+}

--- a/amplify/storage/generateTile/resource.ts
+++ b/amplify/storage/generateTile/resource.ts
@@ -1,0 +1,9 @@
+import { defineFunction } from '@aws-amplify/backend';
+
+export const generateTile = defineFunction({
+  name: 'generateTile',
+  entry: './handler.mjs',
+  runtime: 20,
+  timeoutSeconds: 30,
+  memoryMB: 2048,
+});

--- a/amplify/storage/resource.ts
+++ b/amplify/storage/resource.ts
@@ -1,4 +1,5 @@
 import { defineStorage } from "@aws-amplify/backend"
+import { generateTile } from "./generateTile/resource"
 import { handleS3Upload } from "./handleS3Upload/resource"
 import { processImages } from "../functions/processImages/resource"
 import { runPointFinder } from "../functions/runPointFinder/resource"
@@ -20,6 +21,7 @@ export const outputBucket = defineStorage({
   isDefault: true,
   access: allow => ({
     'slippymaps/*': [
+      allow.resource(generateTile).to(['write', 'list', 'get']),
       allow.resource(handleS3Upload).to(['write', 'list', 'get', 'delete']),
       allow.authenticated.to(['read']),
       allow.groups(['sysadmin']).to(['read', 'write', 'delete'])
@@ -102,6 +104,7 @@ export const inputBucket = defineStorage({
   name: "inputs",
   access: allow => ({
     'images/*': [
+      allow.resource(generateTile).to(['get']),
       allow.resource(handleS3Upload).to(['get']),
       allow.resource(processImages).to(['read']),
       allow.resource(runHeatmapper).to(['read']),

--- a/src/StorageLayer.tsx
+++ b/src/StorageLayer.tsx
@@ -5,10 +5,12 @@ import {
 } from '@react-leaflet/core';
 import { getUrl } from 'aws-amplify/storage';
 import L from 'leaflet';
-import localforage from 'localforage'; // You'll need to install this
+import localforage from 'localforage';
+import { limitedClient } from './limitedClient';
+
 /* This is a custom Leaflet layer that uses a slippy map stored on S3 storage, accessed via the aws-sdk/aws-s3
-library. Because the URLs that we use to access files stored there need to be individually signed, we cannot 
-use a URL template in the way that the normal Leaflet TileLayer does. 
+library. Because the URLs that we use to access files stored there need to be individually signed, we cannot
+use a URL template in the way that the normal Leaflet TileLayer does.
 
 The amplify Storage library gives a slightly more convenient interface, but it can only support a single S3 bucket.
 Having now placed our inputs and outputs in separate buckets, we find that we need to access at least one of these via raw S3.*/
@@ -18,6 +20,110 @@ const tileCache = localforage.createInstance({
   name: 'tileCache',
   storeName: 'tiles',
 });
+
+/**
+ * Tile generation is batched client-side: concurrent Lambda calls for the same
+ * source image are coalesced into a single AppSync call so the Lambda amortizes
+ * one source fetch+decode across many tiles. We use setTimeout(0) rather than a
+ * debounce window — any requests made in the current event-loop tick are swept
+ * into the same batch, with no artificial latency.
+ */
+
+type PendingTile = {
+  z: number;
+  row: number;
+  col: number;
+  resolve: (blob: Blob) => void;
+  reject: (err: Error) => void;
+};
+
+const pendingByImage = new Map<string, PendingTile[]>();
+const timersByImage = new Map<string, ReturnType<typeof setTimeout>>();
+
+function base64ToBlob(b64: string): Blob {
+  const binaryString = atob(b64);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return new Blob([bytes], { type: 'image/png' });
+}
+
+async function flushBatch(imageKey: string, batch: PendingTile[]) {
+  try {
+    const { data, errors } = await (limitedClient as any).queries.generateTile({
+      imageKey,
+      zs: batch.map((t) => t.z),
+      rows: batch.map((t) => t.row),
+      cols: batch.map((t) => t.col),
+    });
+
+    if (errors?.length) throw new Error(errors[0].message);
+    if (!data || !Array.isArray(data)) throw new Error('No tile data returned');
+
+    data.forEach((b64: string | null, i: number) => {
+      if (!b64) {
+        batch[i].reject(new Error('Tile generation returned empty result'));
+        return;
+      }
+      batch[i].resolve(base64ToBlob(b64));
+    });
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    batch.forEach((t) => t.reject(error));
+  }
+}
+
+function generateTileOnDemand(
+  imageKey: string,
+  z: number,
+  row: number,
+  col: number
+): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    let queue = pendingByImage.get(imageKey);
+    if (!queue) {
+      queue = [];
+      pendingByImage.set(imageKey, queue);
+    }
+    queue.push({ z, row, col, resolve, reject });
+
+    if (!timersByImage.has(imageKey)) {
+      const timer = setTimeout(() => {
+        timersByImage.delete(imageKey);
+        const batch = pendingByImage.get(imageKey);
+        pendingByImage.delete(imageKey);
+        if (batch && batch.length > 0) {
+          void flushBatch(imageKey, batch);
+        }
+      }, 0);
+      timersByImage.set(imageKey, timer);
+    }
+  });
+}
+
+/**
+ * Parse a slippy map tile path to extract the image key, zoom, row, and col.
+ * Path format: slippymaps/{sourceKey}/{z}/{row}/{col}.png
+ * Returns the full images/ key needed by the Lambda.
+ */
+function parseTilePath(path: string): {
+  imageKey: string;
+  z: number;
+  row: number;
+  col: number;
+} | null {
+  const match = path.match(
+    /^slippymaps\/(.+)\/(\d+)\/(\d+)\/(\d+)\.png$/
+  );
+  if (!match) return null;
+  return {
+    imageKey: `images/${match[1]}`,
+    z: parseInt(match[2], 10),
+    row: parseInt(match[3], 10),
+    col: parseInt(match[4], 10),
+  };
+}
 
 export async function getTileBlob(path: string): Promise<Blob> {
   // Try to get from persistent cache first
@@ -61,8 +167,24 @@ export async function getTileBlob(path: string): Promise<Blob> {
     }
   }
 
-  // Default path (no special bucket)
-  return await attemptFetch({ path });
+  // Default path: try S3 direct first — for already-tiled images this is the
+  // fast path (one network hop, progressive reveal). On 404, fall through to
+  // the batched Lambda call, which handles generation + write-back.
+  try {
+    return await attemptFetch({ path });
+  } catch (_) {
+    const parsed = parseTilePath(path);
+    if (!parsed) throw new Error(`Cannot parse tile path: ${path}`);
+
+    const blob = await generateTileOnDemand(
+      parsed.imageKey,
+      parsed.z,
+      parsed.row,
+      parsed.col
+    );
+    await tileCache.setItem(path, blob);
+    return blob;
+  }
 }
 
 // Add this type declaration before the extension


### PR DESCRIPTION
Introduces an AppSync-fronted Lambda (generateTile) that tiles source images on demand when a requested tile is not already present on S3. The client flow is now: local cache -> direct S3 fetch -> Lambda fallback on 404. This runs alongside the existing eager handleS3Upload tiler, so freshly uploaded images continue to be fully pre-tiled and the on-demand path only fires for gaps or future use cases where eager tiling is disabled.