### PR TITLE
fix: keep long-running upload sessions authenticated and protected

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -98,6 +98,15 @@ const backend = defineBackend({
   extendTileLifecycles,
 });
 
+const userPoolClient = backend.auth.resources.cfnResources.cfnUserPoolClient;
+userPoolClient.accessTokenValidity = 24 * 60;
+userPoolClient.idTokenValidity = 24 * 60;
+userPoolClient.tokenValidityUnits = {
+  accessToken: 'minutes',
+  idToken: 'minutes',
+  refreshToken: 'days',
+};
+
 const observationTable = backend.data.resources.tables['Observation'];
 const annotationTable = backend.data.resources.tables['Annotation'];
 // Allow the updateUserStats Lambda to read Observation DynamoDB streams.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,35 @@ function App({ signOut = () => { }, user }: AppProps) {
     e.preventDefault();
     e.returnValue = '';
   };
+
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState !== 'visible') return;
+      fetchAuthSession({ forceRefresh: true }).catch((err) => {
+        console.error('Token refresh on tab focus failed', err);
+      });
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => document.removeEventListener('visibilitychange', onVisible);
+  }, []);
+
+  useEffect(() => {
+    const refreshWithRetry = async (attempt = 0): Promise<void> => {
+      try {
+        await fetchAuthSession({ forceRefresh: true });
+      } catch (err) {
+        if (attempt < 3) {
+          const backoffMs = 2000 * 2 ** attempt;
+          await new Promise((r) => setTimeout(r, backoffMs));
+          return refreshWithRetry(attempt + 1);
+        }
+        console.error('Periodic token refresh failed after retries', err);
+      }
+    };
+    const intervalMs = 45 * 60 * 1000;
+    const id = setInterval(refreshWithRetry, intervalMs);
+    return () => clearInterval(id);
+  }, []);
   useEffect(() => {
     fetchAuthSession().then((sess) => {
       setSession(sess);

--- a/src/survey/Surveys.tsx
+++ b/src/survey/Surveys.tsx
@@ -209,6 +209,9 @@ export default function Surveys() {
         );
         return data;
       },
+      // Poll every 60s while a project is uploading so other viewers see the uploader's heartbeat
+      refetchInterval: (query: { state: { data?: Schema['Project']['type'] | null } }) =>
+        query.state.data?.status === 'uploading' ? 60000 : false,
     })),
   });
 

--- a/src/upload/UploadManager.tsx
+++ b/src/upload/UploadManager.tsx
@@ -1464,19 +1464,24 @@ export default function UploadManager() {
     let pingInterval: NodeJS.Timeout | null = null;
 
     if (projectId && !isComplete) {
-      // Function to perform an empty update
       const pingProject = async () => {
         try {
-          await client.models.Project.update({
+          const { data, errors } = await client.models.Project.update({
             id: projectId,
+            status: 'uploading',
           });
-          console.log(`Pinged project ${projectId}`);
+          if (errors?.length) {
+            console.error(`Ping failed for project ${projectId}:`, errors);
+          } else if (!data) {
+            console.error(`Ping returned no data for project ${projectId}`);
+          } else {
+            console.log(`Pinged project ${projectId}`);
+          }
         } catch (error) {
           console.error('Error pinging project:', error);
         }
       };
 
-      // Set interval to ping every minute
       pingInterval = setInterval(pingProject, 60000);
     }
 
@@ -1484,6 +1489,46 @@ export default function UploadManager() {
     return () => {
       if (pingInterval) {
         clearInterval(pingInterval);
+      }
+    };
+  }, [projectId, isComplete]);
+
+  // Hold a screen wake lock while an upload is in flight so the OS doesn't sleep the machine and the browser doesn't freeze/throttle the tab
+  useEffect(() => {
+    if (!projectId || isComplete) return;
+    if (!('wakeLock' in navigator)) return;
+
+    let sentinel: WakeLockSentinel | null = null;
+    let cancelled = false;
+
+    const acquire = async () => {
+      try {
+        const lock = await navigator.wakeLock.request('screen');
+        if (cancelled) {
+          lock.release().catch(() => {});
+          return;
+        }
+        sentinel = lock;
+      } catch (err) {
+        console.warn('Wake lock request failed', err);
+      }
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible' && !sentinel) {
+        acquire();
+      }
+    };
+
+    acquire();
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      if (sentinel) {
+        sentinel.release().catch(() => {});
+        sentinel = null;
       }
     };
   }, [projectId, isComplete]);


### PR DESCRIPTION
Auth session longevity:
- Extend Cognito access/ID token validity from 1h to 24h so fewer silent refreshes are needed per session (refresh token unchanged).
- Force-refresh tokens on tab visibility change to catch the post-freeze wake-up path cleanly.
- Periodic 45-min token refresh with retry/backoff so idle foreground tabs survive transient network blips instead of getting signed out by an uncaught refresh failure.
- Hold a screen wake lock while an upload is in flight to prevent OS sleep and Chrome tab-discard from breaking the refresh flow.

Upload liveness / delete protection:
- Fix the 60s project ping: write status='uploading' (idempotent) instead of a bare {id} update, which was a no-op on some Amplify configurations
- Poll each uploading project every 60s on the Surveys page so other viewers' caches see the fresh updatedAt and the 5-min isStale check that gates the delete button stays accurate.