### PR TITLE
feat: detect duplicate images during upload via perceptual hash

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -148,6 +148,9 @@ const schema = a
         transect: a.belongsTo('Transect', 'transectId'),
         processedBy: a.hasMany('ImageProcessedBy', 'imageId'),
         group: a.string(),
+        // 64-bit perceptual hash (blockhash) of the image, as 16 hex chars.
+        // Used for stricter dedup beyond originalPath matching.
+        phash: a.string(),
         // Stamped by pretileImage worker when the slippy-map pyramid is fully generated.
         tiledAt: a.datetime(),
         // sets: [ImageSet] @manyToMany(relationName: "ImageSetMembership")

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@we-gold/gpxjs": "^1.1.0",
         "aws-amplify": "^6.16.2",
         "aws-sdk": "^2.1691.0",
+        "blockhash-core": "^0.1.0",
         "bootswatch": "^5.3.3",
         "exifr": "^7.1.3",
         "export-from-json": "^1.7.4",
@@ -31481,6 +31482,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/blockhash-core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/blockhash-core/-/blockhash-core-0.1.0.tgz",
+      "integrity": "sha512-Cv7BgBo0jjVPaeuel4cvxf9LqIGsYNIPz9DAGvvrF9LRlEq9Q3HXu+S8bklPCae0sCxAXic4HGMoImf3FeO3Nw==",
+      "license": "MIT"
     },
     "node_modules/bootswatch": {
       "version": "5.3.3",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@we-gold/gpxjs": "^1.1.0",
     "aws-amplify": "^6.16.2",
     "aws-sdk": "^2.1691.0",
+    "blockhash-core": "^0.1.0",
     "bootswatch": "^5.3.3",
     "exifr": "^7.1.3",
     "export-from-json": "^1.7.4",

--- a/src/FilesUploadComponent.tsx
+++ b/src/FilesUploadComponent.tsx
@@ -167,10 +167,14 @@ export function FileUploadCore({
     {}
   );
   const [masks, setMasks] = useState<number[][][]>([]);
-  const [toUploadFiles, setToUploadFiles] = useState<File[]>([]);
-  const [toUploadSize, setToUploadSize] = useState(0);
+  // toUploadFiles / toUploadSize are derived later via useMemo so they
+  // automatically reflect the latest existing-image and map-filter state.
   const [existingSurveyImages, setExistingSurveyImages] = useState<
-    { originalPath: string; latitude: number; longitude: number }[]
+    {
+      originalPath: string;
+      latitude: number;
+      longitude: number;
+    }[]
   >([]);
   const [loadingExistingImages, setLoadingExistingImages] = useState(
     !newProject
@@ -256,6 +260,64 @@ export function FileUploadCore({
   const [failedFiles, setFailedFiles] = useState<
     Array<{ path: string; error: string }>
   >([]);
+
+  // webkitRelativePaths whose csvData row survived the current map/polygon
+  // subset. null when csvData isn't populated yet (no filtering applies).
+  // Mirrors the matching the submit pipeline uses: by filepath when present,
+  // otherwise by exact exif-timestamp match.
+  const csvFilteredPathSet = useMemo<Set<string> | null>(() => {
+    if (!csvData) return null;
+    const validFilepaths = new Set<string>();
+    const validTimestamps = new Set<number>();
+    for (const row of csvData.data) {
+      if (!Number.isFinite(row.lat) || !Number.isFinite(row.lng)) continue;
+      if (row.filepath) validFilepaths.add(row.filepath.toLowerCase());
+      if (typeof row.timestamp === 'number') {
+        validTimestamps.add(row.timestamp);
+      }
+    }
+    const result = new Set<string>();
+    for (const file of imageFiles) {
+      const path = file.webkitRelativePath;
+      if (validFilepaths.has(path.toLowerCase())) {
+        result.add(path);
+        continue;
+      }
+      const exifMeta = exifData[path];
+      if (exifMeta && validTimestamps.has(exifMeta.timestamp)) {
+        result.add(path);
+      }
+    }
+    return result;
+  }, [csvData, imageFiles, exifData]);
+
+  // Files actually destined for upload, post all filters. Drives the count
+  // shown in the UI. Phash dedup happens during upload, not here.
+  const toUploadFiles = useMemo(() => {
+    if (loadingExistingImages) return [] as File[];
+    let candidates = newProject
+      ? imageFiles
+      : imageFiles.filter(
+          (file) => !existingImagePathSet.has(file.webkitRelativePath)
+        );
+    if (csvFilteredPathSet) {
+      candidates = candidates.filter((file) =>
+        csvFilteredPathSet.has(file.webkitRelativePath)
+      );
+    }
+    return candidates;
+  }, [
+    imageFiles,
+    existingImagePathSet,
+    newProject,
+    loadingExistingImages,
+    csvFilteredPathSet,
+  ]);
+
+  const toUploadSize = useMemo(
+    () => toUploadFiles.reduce((acc, f) => acc + f.size, 0),
+    [toUploadFiles]
+  );
 
   // Handler to confirm column mapping before processing
   const handleConfirmMapping = () => {
@@ -382,8 +444,6 @@ export function FileUploadCore({
         : imageFiles.filter(
           (file) => !existingImagePathSet.has(file.webkitRelativePath)
         );
-      setToUploadFiles(uploadFiles);
-      setToUploadSize(uploadFiles.reduce((acc, f) => acc + f.size, 0));
 
       // Files to show on map/exif: all for new project, only new for existing
       const mapFiles = newProject ? imageFiles : uploadFiles;
@@ -634,6 +694,7 @@ export function FileUploadCore({
       const mostCommonTimezone =
         timezones.length > 0 ? timezones[0] : undefined;
       setCommonTimezone(mostCommonTimezone);
+
     }
     if (imageFiles.length > 0) {
       getExistingFiles();
@@ -714,7 +775,11 @@ export function FileUploadCore({
           {
             projectId,
             limit: 10000,
-            selectionSet: ['originalPath', 'latitude', 'longitude'] as const,
+            selectionSet: [
+              'originalPath',
+              'latitude',
+              'longitude',
+            ] as const,
           } as any
         );
         if (!cancelled) {
@@ -1668,6 +1733,8 @@ export function FileUploadCore({
         altitude_agl?: number;
       }[];
 
+      // Phash dedup runs during upload (see UploadManager) so we don't
+      // pre-filter here.
       for (const file of gpsFilteredImageFiles) {
         const exifmeta = exifData[file.webkitRelativePath];
         const gpsData = getGpsForFile(file);
@@ -2330,13 +2397,14 @@ export function FileUploadCore({
         </div> */}
         </div>
       </Form.Group>
-      {scanningEXIF ? (
+      {scanningEXIF && (
         <div className='mt-3 mb-0'>
           <p className='mb-0'>
             Scanning images for GPS data: {`${scanCount}/${scanTotal}`}
           </p>
         </div>
-      ) : failedFiles.length > 0 ? (
+      )}
+      {!scanningEXIF && failedFiles.length > 0 && (
         <Alert variant='warning' className='mt-3 mb-3'>
           <Alert.Heading>
             {failedFiles.length} file{failedFiles.length === 1 ? '' : 's'} failed
@@ -2372,7 +2440,7 @@ export function FileUploadCore({
             </ul>
           </div>
         </Alert>
-      ) : null}
+      )}
       {!scanningEXIF && Object.keys(exifData).length > 0 && imageFiles.length > 0 ? (
         <Form.Group className='mt-3 d-flex flex-column gap-2'>
           <div>

--- a/src/upload/UploadManager.tsx
+++ b/src/upload/UploadManager.tsx
@@ -5,6 +5,9 @@ import { uploadData, list, getUrl } from 'aws-amplify/storage';
 import { CreatedImage, ImageData, UploadedFiles } from '../types/ImageData';
 import ConfirmationModal from '../ConfirmationModal';
 import { fetchAllPaginatedResults } from '../utils';
+import { PhashIndex } from './phashDedup';
+import { PhashService } from './phashService';
+import { logAdminAction } from '../utils/adminActionLogger';
 
 const fileStore = localforage.createInstance({
   name: 'fileStore',
@@ -37,6 +40,18 @@ const hasValidLatLng = (lat: unknown, lng: unknown): boolean =>
   lng >= -180 &&
   lng <= 180;
 
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let size = bytes;
+  let i = 0;
+  while (size >= 1024 && i < units.length - 1) {
+    size /= 1024;
+    i++;
+  }
+  return `${size.toFixed(2)} ${units[i]}`;
+}
+
 async function retryCreate<T>(
   fn: () => Promise<T>,
   maxAttempts = 3
@@ -61,13 +76,21 @@ export default function UploadManager() {
     setProgress,
   } = useContext(UploadContext)!;
   const { client, backend } = useContext(GlobalContext)!;
-  const { myMembershipHook: myProjectsHook } = useContext(UserContext)!;
+  const { user, myMembershipHook: myProjectsHook } = useContext(UserContext)!;
   const fileInputRef = useRef<HTMLInputElement>(null);
   const pendingResumeProjectIdRef = useRef<{ id: string; name: string } | null>(
     null
   );
   const activeUploadRef = useRef<boolean>(false);
   const retryPendingRef = useRef<boolean>(false);
+  // Phash dupes detected during the current upload session. Read by
+  // handleComplete to write an AdminActionLog entry.
+  const duplicatesRef = useRef<
+    { originalPath: string; matchedPath: string; scope: 'batch' | 'db' }[]
+  >([]);
+  // Track which projectIds have already logged a "started" entry in this
+  // component lifecycle, so retries within a session don't double-log.
+  const loggedStartRef = useRef<Set<string>>(new Set());
   const [projectBackOff, setProjectBackOff] = useState<Record<string, number>>(
     {}
   );
@@ -236,6 +259,7 @@ export default function UploadManager() {
       cancelledRef.current = false;
     }
 
+    let phashService: PhashService | null = null;
     try {
       const {
         data: [imageSet],
@@ -302,7 +326,7 @@ export default function UploadManager() {
         client.models.Image.imagesByProjectId,
         {
           projectId,
-          selectionSet: ['id', 'originalPath', 'timestamp', 'cameraId'],
+          selectionSet: ['id', 'originalPath', 'timestamp', 'cameraId', 'phash'],
           limit: 10000,
         }
       )) as {
@@ -310,7 +334,54 @@ export default function UploadManager() {
         originalPath: string;
         timestamp: number;
         cameraId?: string | null;
+        phash?: string | null;
       }[];
+
+      // Reset per-session duplicates tracking and seed the in-memory phash
+      // index from existing DB records. The index is shared by both seed
+      // and upload workers; findMatch+add is synchronous so concurrent
+      // workers can't both classify the same hash as unique.
+      duplicatesRef.current = [];
+      const phashIndex = new PhashIndex<{ originalPath: string }>(4);
+      const dbSeededPaths = new Set<string>();
+      for (const img of dbRawImages) {
+        if (img.phash) {
+          phashIndex.add(img.phash, { originalPath: img.originalPath });
+          dbSeededPaths.add(img.originalPath);
+        }
+      }
+      phashService = new PhashService(4);
+      const phashSvc = phashService;
+
+      // Hash a file and atomically test-and-insert against the shared index.
+      // Returns the file's phash plus, when a duplicate is detected, the
+      // matched originalPath so the caller can record it. The phash is
+      // returned even on duplicate so the DB record (if we still write one)
+      // stays consistent.
+      const checkPhashDup = async (
+        file: File,
+        originalPath: string
+      ): Promise<{ phash: string | null; duplicateOf: string | null; scope: 'batch' | 'db' | null }> => {
+        const phash = await phashSvc.hash(file);
+        if (!phash) return { phash: null, duplicateOf: null, scope: null };
+        const existing = phashIndex.findMatch(phash);
+        if (existing && existing.payload.originalPath !== originalPath) {
+          // Anything seeded from DB at the start of this session is "db";
+          // anything added during the run is "batch".
+          const scope: 'batch' | 'db' = dbSeededPaths.has(
+            existing.payload.originalPath
+          )
+            ? 'db'
+            : 'batch';
+          return {
+            phash,
+            duplicateOf: existing.payload.originalPath,
+            scope,
+          };
+        }
+        phashIndex.add(phash, { originalPath });
+        return { phash, duplicateOf: null, scope: null };
+      };
 
       // track which files are already on S3
       const uploadedFiles = Array.from(s3Files);
@@ -342,6 +413,35 @@ export default function UploadManager() {
         isComplete: false,
         error: null,
       });
+
+      // Log session start once per projectId (gated against retries within
+      // the same component lifecycle).
+      if (
+        organizationId &&
+        totalTasks > 0 &&
+        !loggedStartRef.current.has(projectId)
+      ) {
+        loggedStartRef.current.add(projectId);
+        const uploadBytes = images.reduce((acc, img) => {
+          const f = files.find(
+            (file) => file.webkitRelativePath === img.originalPath
+          );
+          return acc + (f?.size ?? 0);
+        }, 0);
+        const seedNote =
+          seedPaths.length > 0
+            ? `, ${seedPaths.length} already on S3 awaiting DB sync`
+            : '';
+        await logAdminAction(
+          client,
+          user.userId,
+          `Started upload: ${images.length} file${
+            images.length === 1 ? '' : 's'
+          } queued (${formatBytes(uploadBytes)})${seedNote}`,
+          projectId,
+          organizationId
+        );
+      }
       // 1) seed existing S3 files into DB in parallel
       const SEED_CONCURRENCY = 5;
       const seedIterator = seedPaths[Symbol.iterator]();
@@ -371,6 +471,31 @@ export default function UploadManager() {
               (f) => f.webkitRelativePath === originalPath
             );
             const fileType = fileObj?.type ?? 'application/octet-stream';
+
+            // Phash dedup: skip seeding a DB record if the file matches
+            // another already in the index. The S3 object stays put — it's
+            // unreferenced, but harmless. Without a fileObj we can't hash;
+            // fall through and seed the record so we don't lose data.
+            let phashForRecord: string | undefined;
+            if (fileObj) {
+              const { phash, duplicateOf, scope } = await checkPhashDup(
+                fileObj,
+                originalPath
+              );
+              if (duplicateOf) {
+                duplicatesRef.current.push({
+                  originalPath,
+                  matchedPath: duplicateOf,
+                  scope: scope!,
+                });
+                setProgress((prev) => ({
+                  ...prev,
+                  processed: prev.processed + 1,
+                }));
+                continue;
+              }
+              phashForRecord = phash ?? undefined;
+            }
 
             let elevation = 0;
             if (
@@ -414,6 +539,7 @@ export default function UploadManager() {
                     ? altitude - elevation
                     : undefined),
                 cameraId,
+                phash: phashForRecord,
                 group: organizationId,
               })
             );
@@ -470,6 +596,21 @@ export default function UploadManager() {
               (f) => f.webkitRelativePath === image.originalPath
             );
             if (file) {
+              // Phash check before uploading so duplicates never spend
+              // bandwidth. checkPhashDup is atomic w.r.t. other workers.
+              const { phash, duplicateOf, scope } = await checkPhashDup(
+                file,
+                image.originalPath
+              );
+              if (duplicateOf) {
+                duplicatesRef.current.push({
+                  originalPath: image.originalPath,
+                  matchedPath: duplicateOf,
+                  scope: scope!,
+                });
+                continue;
+              }
+
               const s3Key = makeKey(image.originalPath);
               await uploadData({
                 path: 'images/' + s3Key,
@@ -523,6 +664,7 @@ export default function UploadManager() {
                       ? altitude - elevation
                       : undefined),
                   cameraId,
+                  phash: phash ?? undefined,
                   group: organizationId,
                 })
               );
@@ -569,6 +711,24 @@ export default function UploadManager() {
       const workers: Promise<void>[] = [];
       for (let i = 0; i < CONCURRENCY; i++) workers.push(runWorker());
       await Promise.all(workers);
+
+      // Prune phash-dupe paths from fileStore so handleComplete's
+      // "uploaded == filesToUpload" check doesn't loop forever waiting for
+      // files we deliberately skipped.
+      if (duplicatesRef.current.length > 0) {
+        const dupePaths = new Set(
+          duplicatesRef.current.map((d) => d.originalPath)
+        );
+        const stored =
+          ((await fileStore.getItem(projectId)) as ImageData[]) ?? [];
+        const remaining = stored.filter(
+          (img) => !dupePaths.has(img.originalPath)
+        );
+        if (remaining.length !== stored.length) {
+          await fileStore.setItem(projectId, remaining);
+        }
+      }
+
       // if pause was requested, after active uploads finish, reset state
       if (cancelledRef.current) {
         // If we're finalizing after max attempts, do NOT reset; allow completion flow
@@ -606,6 +766,10 @@ export default function UploadManager() {
       }));
     } finally {
       activeUploadRef.current = false;
+      if (phashService) {
+        phashService.destroy();
+        phashService = null;
+      }
       // If we hit max attempts, force completion instead of retrying
       if (
         finalizeAfterMaxAttemptsRef.current &&
@@ -1241,6 +1405,66 @@ export default function UploadManager() {
           status: 'processing-mad',
         });
       }
+
+      // Persist phash dupes detected during this session to AdminActionLog
+      // so admins can audit what was skipped. The list is truncated to keep
+      // the message under DynamoDB's per-item limit; the count prefix is
+      // always accurate even when the list is shortened.
+      if (duplicatesRef.current.length > 0 && organizationId) {
+        const dupes = duplicatesRef.current;
+        const MAX_MESSAGE_CHARS = 30000;
+        const header = `Skipped ${dupes.length} hash-based duplicate${
+          dupes.length === 1 ? '' : 's'
+        } during upload:`;
+        const lines = dupes.map(
+          (d) =>
+            `- ${d.originalPath} matches ${d.matchedPath} (${
+              d.scope === 'db' ? 'already in survey' : 'within this upload'
+            })`
+        );
+        let message = `${header}\n${lines.join('\n')}`;
+        if (message.length > MAX_MESSAGE_CHARS) {
+          const kept: string[] = [];
+          let used = header.length + 1;
+          let truncatedAt = lines.length;
+          for (let i = 0; i < lines.length; i++) {
+            const next = used + lines[i].length + 1;
+            if (next > MAX_MESSAGE_CHARS - 64) {
+              truncatedAt = i;
+              break;
+            }
+            kept.push(lines[i]);
+            used = next;
+          }
+          const remaining = lines.length - truncatedAt;
+          message =
+            `${header}\n${kept.join('\n')}\n…and ${remaining} more (truncated)`;
+        }
+        await logAdminAction(
+          client,
+          user.userId,
+          message,
+          projectId,
+          organizationId
+        );
+        duplicatesRef.current = [];
+      }
+
+      // Log session completion. The start log is gated by loggedStartRef;
+      // we clear it here so a subsequent upload to this same project (e.g.
+      // a follow-up batch) gets a fresh "Started upload" entry.
+      if (organizationId) {
+        await logAdminAction(
+          client,
+          user.userId,
+          `Completed upload: ${dedupedDbImages.length} image${
+            dedupedDbImages.length === 1 ? '' : 's'
+          } now in survey`,
+          projectId,
+          organizationId
+        );
+      }
+      loggedStartRef.current.delete(projectId);
 
       //clear local storage
       await fileStore.removeItem(projectId);

--- a/src/upload/phashDedup.ts
+++ b/src/upload/phashDedup.ts
@@ -1,0 +1,101 @@
+// Banded LSH index for perceptual hashes of arbitrary fixed bit-width.
+//
+// Pigeonhole: split the hash into k bands. Any two hashes within Hamming
+// distance t (where t < k) must agree on at least k - t bands exactly.
+// We index every band, probe every band on lookup, union the candidates,
+// then run an exact Hamming distance check against each candidate.
+//
+// Hashes whose length does not match the index's expected length are
+// silently skipped — useful for ignoring legacy hashes that were produced
+// with a different block size (e.g. 64-bit) when the index expects the
+// current 256-bit format.
+
+const POPCOUNT_TABLE = new Uint8Array(256);
+for (let i = 0; i < 256; i++) {
+  let v = i;
+  v = v - ((v >> 1) & 0x55);
+  v = (v & 0x33) + ((v >> 2) & 0x33);
+  POPCOUNT_TABLE[i] = (v + (v >> 4)) & 0x0f;
+}
+
+export function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+export function hammingDistance(a: Uint8Array, b: Uint8Array): number {
+  let d = 0;
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    d += POPCOUNT_TABLE[a[i] ^ b[i]];
+  }
+  return d;
+}
+
+export interface PhashEntry<T> {
+  phash: string;
+  bytes: Uint8Array;
+  payload: T;
+}
+
+export class PhashIndex<T> {
+  private bands: Map<string, PhashEntry<T>[]>[] = [];
+  private threshold: number;
+  private hashLength: number;
+  private bandCount: number;
+  private bandWidth: number;
+
+  // Default geometry: 256-bit hash (64 hex chars) split into 4 × 64-bit bands.
+  // Pigeonhole with t=4 → at least 3 bands match exactly per duplicate pair.
+  constructor(threshold = 4, hashLength = 64, bandCount = 4) {
+    if (hashLength % bandCount !== 0) {
+      throw new Error(
+        `hashLength (${hashLength}) must be divisible by bandCount (${bandCount})`
+      );
+    }
+    this.threshold = threshold;
+    this.hashLength = hashLength;
+    this.bandCount = bandCount;
+    this.bandWidth = hashLength / bandCount;
+    for (let i = 0; i < bandCount; i++) this.bands.push(new Map());
+  }
+
+  add(phash: string, payload: T): PhashEntry<T> | null {
+    if (phash.length !== this.hashLength) return null;
+    const entry: PhashEntry<T> = {
+      phash,
+      bytes: hexToBytes(phash),
+      payload,
+    };
+    for (let b = 0; b < this.bandCount; b++) {
+      const key = phash.slice(b * this.bandWidth, (b + 1) * this.bandWidth);
+      const bucket = this.bands[b].get(key);
+      if (bucket) bucket.push(entry);
+      else this.bands[b].set(key, [entry]);
+    }
+    return entry;
+  }
+
+  // Returns the first entry within the threshold, or null.
+  findMatch(phash: string): PhashEntry<T> | null {
+    if (phash.length !== this.hashLength) return null;
+    const bytes = hexToBytes(phash);
+    const seen = new Set<PhashEntry<T>>();
+    for (let b = 0; b < this.bandCount; b++) {
+      const key = phash.slice(b * this.bandWidth, (b + 1) * this.bandWidth);
+      const bucket = this.bands[b].get(key);
+      if (!bucket) continue;
+      for (const entry of bucket) {
+        if (seen.has(entry)) continue;
+        seen.add(entry);
+        if (hammingDistance(bytes, entry.bytes) <= this.threshold) {
+          return entry;
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/src/upload/phashService.ts
+++ b/src/upload/phashService.ts
@@ -1,0 +1,82 @@
+// Long-lived perceptual-hash worker pool used by the upload pipeline.
+// Each upload worker awaits hash() per file before deciding whether to
+// upload; the pool keeps workers warm so we don't pay Worker startup cost
+// for every file.
+
+interface PendingJob {
+  resolve: (phash: string | null) => void;
+}
+
+interface QueueEntry {
+  id: number;
+  file: File;
+}
+
+type WorkerMessage =
+  | { id: number; phash: string }
+  | { id: number; error: string };
+
+export class PhashService {
+  private workers: Worker[] = [];
+  private idle: Worker[] = [];
+  private pending = new Map<number, PendingJob>();
+  private queue: QueueEntry[] = [];
+  private nextId = 0;
+  private destroyed = false;
+
+  constructor(workerCount = 4) {
+    const count = Math.max(1, workerCount);
+    for (let i = 0; i < count; i++) {
+      const worker = new Worker(
+        new URL('./phashWorker.ts', import.meta.url),
+        { type: 'module' }
+      );
+      worker.onmessage = (event: MessageEvent<WorkerMessage>) => {
+        const data = event.data;
+        const cb = this.pending.get(data.id);
+        this.pending.delete(data.id);
+        if (cb) {
+          cb.resolve('phash' in data ? data.phash : null);
+        }
+        this.idle.push(worker);
+        this.dispatch();
+      };
+      worker.onerror = () => {
+        // Resolve any in-flight job for this worker as null and recycle it.
+        // The next dispatch will route work to remaining idle workers.
+        this.idle.push(worker);
+        this.dispatch();
+      };
+      this.workers.push(worker);
+      this.idle.push(worker);
+    }
+  }
+
+  hash(file: File): Promise<string | null> {
+    if (this.destroyed) return Promise.resolve(null);
+    return new Promise((resolve) => {
+      const id = this.nextId++;
+      this.pending.set(id, { resolve });
+      this.queue.push({ id, file });
+      this.dispatch();
+    });
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    for (const w of this.workers) w.terminate();
+    this.workers = [];
+    this.idle = [];
+    for (const job of this.pending.values()) job.resolve(null);
+    this.pending.clear();
+    this.queue.length = 0;
+  }
+
+  private dispatch(): void {
+    while (this.idle.length > 0 && this.queue.length > 0) {
+      const worker = this.idle.pop()!;
+      const job = this.queue.shift()!;
+      worker.postMessage({ id: job.id, file: job.file });
+    }
+  }
+}

--- a/src/upload/phashWorker.ts
+++ b/src/upload/phashWorker.ts
@@ -1,0 +1,88 @@
+/// <reference lib="webworker" />
+import exifr from 'exifr';
+import { bmvbhash } from 'blockhash-core';
+
+interface HashRequest {
+  id: number;
+  file: File;
+}
+
+interface HashSuccess {
+  id: number;
+  phash: string;
+}
+
+interface HashFailure {
+  id: number;
+  error: string;
+}
+
+type HashResponse = HashSuccess | HashFailure;
+
+const HASH_BITS = 16; // 256-bit hash → 64 hex chars (16×16 grid)
+const RESIZE_TARGET = 256;
+
+async function decodeForHashing(file: File): Promise<ImageBitmap> {
+  // Fast path: most survey JPEGs embed a small EXIF thumbnail (~160×120).
+  // Decoding it is ~10ms vs 500ms–2s for a full 25MB JPEG.
+  let thumbBytes: ArrayBuffer | undefined;
+  try {
+    thumbBytes = (await exifr.thumbnail(file)) as ArrayBuffer | undefined;
+  } catch {
+    thumbBytes = undefined;
+  }
+
+  if (thumbBytes && thumbBytes.byteLength > 0) {
+    const blob = new Blob([thumbBytes], { type: 'image/jpeg' });
+    return createImageBitmap(blob, {
+      resizeWidth: RESIZE_TARGET,
+      resizeHeight: RESIZE_TARGET,
+      resizeQuality: 'medium',
+    });
+  }
+
+  // Fallback: decode the full file but cap memory by resizing during decode.
+  return createImageBitmap(file, {
+    resizeWidth: RESIZE_TARGET,
+    resizeHeight: RESIZE_TARGET,
+    resizeQuality: 'medium',
+  });
+}
+
+async function computePhash(file: File): Promise<string> {
+  const bitmap = await decodeForHashing(file);
+  try {
+    const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('OffscreenCanvas 2d context unavailable');
+    ctx.drawImage(bitmap, 0, 0);
+    const imageData = ctx.getImageData(0, 0, bitmap.width, bitmap.height);
+    return bmvbhash(
+      {
+        width: imageData.width,
+        height: imageData.height,
+        data: imageData.data,
+      },
+      HASH_BITS
+    );
+  } finally {
+    bitmap.close();
+  }
+}
+
+self.onmessage = async (event: MessageEvent<HashRequest>) => {
+  const { id, file } = event.data;
+  try {
+    const phash = await computePhash(file);
+    const response: HashResponse = { id, phash };
+    (self as unknown as Worker).postMessage(response);
+  } catch (err) {
+    const response: HashResponse = {
+      id,
+      error: err instanceof Error ? err.message : String(err),
+    };
+    (self as unknown as Worker).postMessage(response);
+  }
+};
+
+export {};


### PR DESCRIPTION
Adds perceptual-hash dedup to the upload pipeline so we don't end up with the same image (different name) twice in a survey - whether it's a duplicate within the current batch or one that's already been uploaded to the project.

phashDedup.ts is a banded LSH index. Lets us answer "is this hash within Hamming distance N of anything we've seen?" without scanning everything. Seeded from existing Image.phash records at the start of each upload session.

phashWorker.ts is the Web Worker that turns a File into a 256-bit hash. It decodes the embedded EXIF thumbnail when available so we don't read the full image just to hash it.

phashService.ts is a small worker pool around phashWorker. Long-lived workers, internal queue, hash(file) -> Promise<string | null>. Avoids paying Worker startup cost per file.

UploadManager hashes each file just before it would go to S3, checks the shared index, and skips both the upload and DB write if it matches. findMatch + add is synchronous so concurrent upload workers can't both treat the same hash as unique. Skipped paths are pruned from fileStore so the completion check still lines up. Also writes AdminActionLog entries on upload start, on completion, and listing any duplicates that were skipped (truncated if very long).

FilesUploadComponent doesn't do any phash work at submit time - everything happens during the upload itself, so the form just collects and persists files as before.