### PR TITLE
feat: simplify ChainLink workflow - drop lock step, add OOV terminus

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -232,6 +232,7 @@ const schema = a
         y: a.integer().required(),
         obscured: a.boolean(),
         oov: a.boolean(),
+        noPartnerExpected: a.boolean(),
         objectId: a.id(),
         object: a.belongsTo('Object', 'objectId'),
         reviewCatId: a.string(),

--- a/src/individual-id/IndividualIdHarness.tsx
+++ b/src/individual-id/IndividualIdHarness.tsx
@@ -108,6 +108,12 @@ type LinkActor = {
    * `existing` is set.
    */
   oov?: boolean;
+  /**
+   * Stamp `noPartnerExpected: true` on the new row. Only meaningful when
+   * `oov: true` and the OOV is being created as a terminus (no partner is
+   * expected on any neighbour pair). Ignored when `existing` is set.
+   */
+  noPartnerExpected?: boolean;
 };
 
 /**
@@ -662,22 +668,6 @@ export function IndividualIdHarness({
     [working, currentPairKey, currentView, persistAnnotationPosition]
   );
 
-  const handleLock = useCallback(
-    (candidateKey: string) => {
-      if (!currentPairKey) return;
-      working.lockCandidate(currentPairKey, candidateKey);
-    },
-    [working, currentPairKey]
-  );
-
-  const handleUnlock = useCallback(
-    (candidateKey: string) => {
-      if (!currentPairKey) return;
-      working.unlockCandidate(currentPairKey, candidateKey);
-    },
-    [working, currentPairKey]
-  );
-
   /**
    * User clicked empty map area to place a brand-new annotation. We create
    * the row in the DB immediately (optimistic local update first) so Munkres
@@ -1023,6 +1013,62 @@ export function IndividualIdHarness({
   );
 
   /**
+   * Toggles an OOV's `noPartnerExpected` flag. Called from the OovPanel
+   * card when the user confirms (or revokes the confirmation) that the
+   * animal is genuinely absent from neighbouring images, so the chain
+   * shouldn't keep nagging for a partner.
+   */
+  const handleToggleNoPartnerExpected = useCallback(
+    async (annotationId: string) => {
+      const current = localAnnotations.find((a) => a.id === annotationId);
+      if (!current) return;
+      const next = !(current as any).noPartnerExpected;
+
+      const apply = (a: AnnotationType): AnnotationType =>
+        a.id === annotationId
+          ? ({ ...a, noPartnerExpected: next } as AnnotationType)
+          : a;
+      const revert = (a: AnnotationType): AnnotationType =>
+        a.id === annotationId
+          ? ({
+              ...a,
+              noPartnerExpected: (current as any).noPartnerExpected,
+            } as AnnotationType)
+          : a;
+
+      setLocalAnnotations((prev) => prev.map(apply));
+      patchTransectCache((old) => {
+        const annotations = old.annotations.map(apply);
+        return {
+          ...old,
+          annotations,
+          annotationsByImage: indexByImage(annotations),
+        };
+      });
+
+      try {
+        await client.models.Annotation.update({
+          id: annotationId,
+          noPartnerExpected: next,
+        } as any);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to toggle noPartnerExpected', err);
+        setLocalAnnotations((prev) => prev.map(revert));
+        patchTransectCache((old) => {
+          const annotations = old.annotations.map(revert);
+          return {
+            ...old,
+            annotations,
+            annotationsByImage: indexByImage(annotations),
+          };
+        });
+      }
+    },
+    [localAnnotations, client, patchTransectCache]
+  );
+
+  /**
    * User clicked "Mark as obscured" on a *proposed* (shadow) marker — there's
    * no DB row yet, so we only record the intent in working state. It rides
    * along when the candidate is accepted and the row is created with
@@ -1293,6 +1339,7 @@ export function IndividualIdHarness({
             group,
             ...(actor.obscured ? { obscured: true } : {}),
             ...(actor.oov ? { oov: true } : {}),
+            ...(actor.noPartnerExpected ? { noPartnerExpected: true } : {}),
             createdAt: nowIso,
             updatedAt: nowIso,
           } as unknown as AnnotationType);
@@ -1453,6 +1500,46 @@ export function IndividualIdHarness({
     [localAnnotations, commitActorLink]
   );
 
+  /**
+   * User clicked "Move to OOV" on a shadow whose candidate has a real
+   * partner on the other side. Materialises a new OOV row on this side
+   * chain-linked to the partner via shared objectId. The OOV is created
+   * *without* `noPartnerExpected` — neighbouring pairs still pull it in
+   * as a candidate, and the user can mark the chain as terminus from the
+   * OovPanel card later if they confirm no partner ever appears.
+   */
+  const handleMoveToOov = useCallback(
+    async (candidateKey: string, oovSide: 'A' | 'B') => {
+      if (!currentPair || !currentView || !currentPairKey) return;
+      const candidate = currentView.candidates.find(
+        (c) => c.pairKey === candidateKey
+      );
+      if (!candidate) return;
+      const partner = oovSide === 'A' ? candidate.realB : candidate.realA;
+      if (!partner) return;
+      const oovImageId =
+        oovSide === 'A' ? currentPair.image1Id : currentPair.image2Id;
+      const actors: LinkActor[] = [
+        {
+          id: partner.id,
+          imageId: partner.imageId,
+          existing: partner,
+          candidatePos: null,
+        },
+        {
+          id: crypto.randomUUID(),
+          imageId: oovImageId,
+          existing: null,
+          candidatePos: { x: 0, y: 0 },
+          oov: true,
+        },
+      ];
+      working.acceptCandidate(currentPairKey, candidateKey);
+      await commitActorLink(actors, candidate.categoryId);
+    },
+    [currentPair, currentView, currentPairKey, working, commitActorLink]
+  );
+
   // ---- Manual-link confirmation ----
   // `active` is the real annotation in the currently-active candidate (on the
   // image opposite the click); `clicked` is the real annotation the user
@@ -1541,14 +1628,14 @@ export function IndividualIdHarness({
             leniency={leniency}
             onLeniencyChange={setLeniency}
             onDrag={handleDrag}
-            onLock={handleLock}
-            onUnlock={handleUnlock}
             onAccept={handleAccept}
             onPlaceNew={handlePlaceNew}
             onDelete={handleDelete}
             onChangeLabel={handleChangeLabel}
             onToggleObscured={handleToggleObscured}
             onSetProposedObscured={handleSetProposedObscured}
+            onMoveToOov={handleMoveToOov}
+            onToggleNoPartnerExpected={handleToggleNoPartnerExpected}
             onManualLinkRequest={requestManualLink}
             onAddOov={handlePlaceOov}
             onAllAccepted={handleAllAccepted}

--- a/src/individual-id/IndividualIdMap.tsx
+++ b/src/individual-id/IndividualIdMap.tsx
@@ -48,6 +48,12 @@ export interface MapMarker {
    * participates in candidates, accept or completion.
    */
   foreign?: boolean;
+  /**
+   * True when this marker is a shadow whose candidate has a real partner
+   * on the other image — i.e. the shadow can be converted to a terminus
+   * OOV chain-linked to that partner via the popup's "Move to OOV" action.
+   */
+  canMoveToOov?: boolean;
 }
 
 export type MapInstanceCallback = (
@@ -106,6 +112,13 @@ interface Props {
    * flag yet.
    */
   onMarkerToggleObscured?: (candidateKey: string) => void;
+  /**
+   * User clicked the "Move to OOV" button on a shadow's popup. The shadow
+   * is materialised as an OOV row chain-linked to the partner real on the
+   * other image, and stamped with `noPartnerExpected: true` so it doesn't
+   * nag neighbouring pairs for a partner.
+   */
+  onMarkerMoveToOov?: (candidateKey: string) => void;
   /**
    * Munkres "leave unmatched" cost in image pixels. Used to render a ring
    * around the active marker so the user can see exactly the radius within
@@ -341,7 +354,6 @@ function applyMarkerStyle(el: HTMLDivElement, m: MapMarker) {
 
   // Active and status are stacked as box-shadows so they compose:
   //   active           → orange ring 0-3px
-  //   locked           → yellow ring (3-6px when active, else 0-3px)
   //   accepted         → green  ring (3-6px when active, else 0-3px)
   //   neither          → subtle 1px outline so the marker stays visible
   //                      against bright tiles.
@@ -353,9 +365,7 @@ function applyMarkerStyle(el: HTMLDivElement, m: MapMarker) {
   } else {
     const shadows: string[] = [];
     if (m.active) shadows.push('0 0 0 3px #ff8c1a'); // orange
-    if (m.status === 'locked') {
-      shadows.push(m.active ? '0 0 0 6px #f1c40f' : '0 0 0 3px #f1c40f');
-    } else if (m.status === 'accepted') {
+    if (m.status === 'accepted') {
       shadows.push(m.active ? '0 0 0 6px #27ae60' : '0 0 0 3px #27ae60');
     } else if (!m.active) {
       shadows.push('0 0 0 1px rgba(0, 0, 0, 0.45)');
@@ -426,6 +436,7 @@ export function IndividualIdMap({
   onMarkerDelete,
   onMarkerChangeLabel,
   onMarkerToggleObscured,
+  onMarkerMoveToOov,
   leniency,
   leniencyAnchor,
   previewTransform,
@@ -453,6 +464,7 @@ export function IndividualIdMap({
   const deleteRef = useRef(onMarkerDelete);
   const changeLabelRef = useRef(onMarkerChangeLabel);
   const toggleObscuredRef = useRef(onMarkerToggleObscured);
+  const moveToOovRef = useRef(onMarkerMoveToOov);
   const addOovRef = useRef(onAddOov);
   useEffect(() => {
     dragRef.current = onMarkerDrag;
@@ -478,6 +490,9 @@ export function IndividualIdMap({
   useEffect(() => {
     toggleObscuredRef.current = onMarkerToggleObscured;
   }, [onMarkerToggleObscured]);
+  useEffect(() => {
+    moveToOovRef.current = onMarkerMoveToOov;
+  }, [onMarkerMoveToOov]);
   useEffect(() => {
     addOovRef.current = onAddOov;
   }, [onAddOov]);
@@ -581,6 +596,10 @@ export function IndividualIdMap({
     const deleteHtml = showFullActions
       ? `<button data-action="delete" style="${btnStyle}background:#d9534f;">Delete</button>`
       : '';
+    const moveToOovHtml =
+      interactive && isShadow && data.canMoveToOov
+        ? `<button data-action="move-to-oov" style="${btnStyle}background:#5B6977;">Move to OOV</button>`
+        : '';
     el.innerHTML = `
       <div style="font-weight:600">${escape(nameFor(data.identityKey))}</div>
       <div style="font-size:10px;opacity:0.7;text-transform:uppercase;letter-spacing:0.4px;margin-top:2px">
@@ -593,6 +612,7 @@ export function IndividualIdMap({
       }
       ${changeLabelHtml}
       ${obscureHtml}
+      ${moveToOovHtml}
       ${deleteHtml}
     `;
     if (showObscureToggle) {
@@ -603,6 +623,18 @@ export function IndividualIdMap({
         obscuredBtn.addEventListener('click', (ev) => {
           ev.stopPropagation();
           toggleObscuredRef.current?.(key);
+          hidePopup();
+        });
+      }
+    }
+    if (moveToOovHtml) {
+      const moveBtn = el.querySelector(
+        'button[data-action="move-to-oov"]'
+      ) as HTMLButtonElement | null;
+      if (moveBtn) {
+        moveBtn.addEventListener('click', (ev) => {
+          ev.stopPropagation();
+          moveToOovRef.current?.(key);
           hidePopup();
         });
       }

--- a/src/individual-id/IndividualIdMapPair.tsx
+++ b/src/individual-id/IndividualIdMapPair.tsx
@@ -23,6 +23,7 @@ import { HelpCircle } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { OovPanel } from './components/OovPanel';
 import { HelpModal } from './components/HelpModal';
+import { isOov } from './utils/identity';
 
 interface Props {
   pair: NeighbourPair;
@@ -38,10 +39,7 @@ interface Props {
     side: 'A' | 'B',
     pos: { x: number; y: number }
   ) => void;
-  /** First space press: mark `locked` in working state. No DB write. */
-  onLock: (candidateKey: string) => void;
-  onUnlock: (candidateKey: string) => void;
-  /** Second space press: commit the link and mark `accepted`. */
+  /** Space press: commit the link and mark `accepted`. */
   onAccept: (candidateKey: string) => void;
   onUnfocus?: () => void;
   /** Harness pre-generates the id so the candidate survives the Munkres rebuild. */
@@ -59,6 +57,14 @@ interface Props {
     side: 'A' | 'B',
     value: boolean
   ) => void;
+  /**
+   * User clicked "Move to OOV" on a shadow whose candidate has a real
+   * partner on the other side. Materialises a terminus OOV chain-linked to
+   * that partner so neighbouring pairs don't nag for further linking.
+   */
+  onMoveToOov?: (candidateKey: string, side: 'A' | 'B') => void;
+  /** Toggle `noPartnerExpected` from an OovPanel card. */
+  onToggleNoPartnerExpected?: (annotationId: string) => void;
   /** Args: active candidate's real id opposite the click, then the ctrl-clicked real id. */
   onManualLinkRequest?: (
     activeAnnotationId: string,
@@ -92,6 +98,7 @@ const NO_MARKERS: MapMarker[] = [];
 // Stable empty defaults so the optional props don't churn memo identities.
 const NO_FOREIGN: AnnotationType[] = [];
 const NO_COLORS: Record<string, string> = {};
+const NOOP_TOGGLE = (_id: string) => {};
 
 // Two-map workspace: renders both maps + markers and the keyboard flow.
 // Never writes the DB and never persists across mounts — the harness owns both.
@@ -104,8 +111,6 @@ export function IndividualIdMapPair(props: Props) {
     category,
     visible,
     onDrag,
-    onLock,
-    onUnlock,
     onAccept,
     onUnfocus,
     onPlaceNew,
@@ -113,6 +118,8 @@ export function IndividualIdMapPair(props: Props) {
     onChangeLabel,
     onToggleObscured,
     onSetProposedObscured,
+    onMoveToOov,
+    onToggleNoPartnerExpected,
     onManualLinkRequest,
     onAllAccepted,
     onRequestPrevPair,
@@ -213,6 +220,8 @@ export function IndividualIdMapPair(props: Props) {
     const out: MapMarker[] = [];
     for (const c of candidates) {
       if (!c.posA) continue;
+      const isShadow = !c.realA || c.isShadowA;
+      const partnerReal = c.realB && !isOov(c.realB) ? c.realB : null;
       out.push({
         candidateKey: c.pairKey,
         side: 'A',
@@ -224,6 +233,7 @@ export function IndividualIdMapPair(props: Props) {
         identityKey: c.pairKey,
         active: c.pairKey === activeKey,
         obscured: c.realA ? !!c.realA.obscured : !!c.obscuredA,
+        canMoveToOov: isShadow && !!partnerReal,
       });
     }
     // Informational markers for annotations belonging to other categories.
@@ -250,6 +260,8 @@ export function IndividualIdMapPair(props: Props) {
     const out: MapMarker[] = [];
     for (const c of candidates) {
       if (!c.posB) continue;
+      const isShadow = !c.realB || c.isShadowB;
+      const partnerReal = c.realA && !isOov(c.realA) ? c.realA : null;
       out.push({
         candidateKey: c.pairKey,
         side: 'B',
@@ -261,6 +273,7 @@ export function IndividualIdMapPair(props: Props) {
         identityKey: c.pairKey,
         active: c.pairKey === activeKey,
         obscured: c.realB ? !!c.realB.obscured : !!c.obscuredB,
+        canMoveToOov: isShadow && !!partnerReal,
       });
     }
     // Informational markers for annotations belonging to other categories.
@@ -467,7 +480,7 @@ export function IndividualIdMapPair(props: Props) {
       }
       return;
     }
-    // Informational can't be locked — Space skips ahead so the flow doesn't get stuck.
+    // Informational can't be linked — Space skips ahead so the flow doesn't get stuck.
     if (activeCandidate.informational) {
       advanceFocus(1);
       return;
@@ -484,11 +497,8 @@ export function IndividualIdMapPair(props: Props) {
       return;
     }
     if (activeCandidate.status === 'pending') {
-      onLock(activeCandidate.pairKey);
-      panToCandidate(activeCandidate.pairKey);
-      return;
-    }
-    if (activeCandidate.status === 'locked') {
+      // Experiment: skip the intermediate "lock" step — Space on a pending
+      // candidate accepts the link directly.
       onAccept(activeCandidate.pairKey);
       // Advance focus within this pair; onAllAccepted is fired by the effect, not here (stale-read race).
       const linkable = candidates.filter((c) => !c.informational);
@@ -518,7 +528,6 @@ export function IndividualIdMapPair(props: Props) {
   }, [
     activeCandidate,
     candidates,
-    onLock,
     onAccept,
     onAllAccepted,
     advanceFocus,
@@ -527,13 +536,10 @@ export function IndividualIdMapPair(props: Props) {
 
   const handleEscape = useCallback(() => {
     if (activeKey) {
-      if (activeCandidate?.status === 'locked') {
-        onUnlock(activeCandidate.pairKey);
-      }
       setActiveKey(null);
       onUnfocus?.();
     }
-  }, [activeKey, activeCandidate, onUnlock, onUnfocus]);
+  }, [activeKey, onUnfocus]);
 
   useHotkeys('Space', handleSpace, { enabled: visible, preventDefault: true }, [
     handleSpace,
@@ -590,13 +596,8 @@ export function IndividualIdMapPair(props: Props) {
 
   // Empty-map click places a new annotation and makes it the active marker
   // (the id is pre-generated so the candidate survives the Munkres rebuild).
-  // Any previously-active marker loses focus, and is unlocked if it was only
-  // locked — an unaccepted lock is working-state only.
   const placeFromClick = useCallback(
     (clickedSide: 'A' | 'B', pos: { x: number; y: number }) => {
-      if (activeCandidate?.status === 'locked') {
-        onUnlock(activeCandidate.pairKey);
-      }
       if (!category || !onPlaceNew) {
         // Can't create here — just drop focus off the active marker.
         if (activeKey) {
@@ -609,7 +610,7 @@ export function IndividualIdMapPair(props: Props) {
       onPlaceNew(clickedSide, pos, newId);
       setActiveKey(newId);
     },
-    [activeKey, activeCandidate, onUnlock, category, onPlaceNew, onUnfocus]
+    [activeKey, category, onPlaceNew, onUnfocus]
   );
 
   const handleMapClickA = useCallback(
@@ -714,6 +715,15 @@ export function IndividualIdMapPair(props: Props) {
     [candidates, onToggleObscured, onSetProposedObscured, foreignById]
   );
 
+  const handleMoveToOovA = useCallback(
+    (candidateKey: string) => onMoveToOov?.(candidateKey, 'A'),
+    [onMoveToOov]
+  );
+  const handleMoveToOovB = useCallback(
+    (candidateKey: string) => onMoveToOov?.(candidateKey, 'B'),
+    [onMoveToOov]
+  );
+
   // Ctrl+click a real marker on the other image to link it with the active
   // candidate's real on the opposite side — only when that side is a
   // shadow/informational proposal, never breaking an existing real↔real link.
@@ -788,6 +798,7 @@ export function IndividualIdMapPair(props: Props) {
           onCtrlClick={handleCtrlClickA}
           onHoverChange={handleHoverA}
           onDelete={handleCardDeleteA}
+          onToggleNoPartnerExpected={onToggleNoPartnerExpected ?? NOOP_TOGGLE}
         />
         <div style={{ flex: 1, minHeight: 0 }}>
           <IndividualIdMap
@@ -803,6 +814,7 @@ export function IndividualIdMapPair(props: Props) {
             onMarkerDelete={handleDeleteA}
             onMarkerChangeLabel={handleChangeLabelA}
             onMarkerToggleObscured={handleToggleObscuredA}
+            onMarkerMoveToOov={handleMoveToOovA}
             onMarkerCtrlClick={handleCtrlClickA}
             onAddOov={addOovA}
             leniency={leniency}
@@ -827,6 +839,7 @@ export function IndividualIdMapPair(props: Props) {
             onMarkerDelete={handleDeleteB}
             onMarkerChangeLabel={handleChangeLabelB}
             onMarkerToggleObscured={handleToggleObscuredB}
+            onMarkerMoveToOov={handleMoveToOovB}
             onMarkerCtrlClick={handleCtrlClickB}
             onAddOov={addOovB}
             leniency={leniency}
@@ -847,6 +860,7 @@ export function IndividualIdMapPair(props: Props) {
           onCtrlClick={handleCtrlClickB}
           onHoverChange={handleHoverB}
           onDelete={handleCardDeleteB}
+          onToggleNoPartnerExpected={onToggleNoPartnerExpected ?? NOOP_TOGGLE}
         />
       </div>
       <PairToolbar
@@ -901,9 +915,7 @@ function PairToolbar({
 
   const status = active
     ? active.status === 'pending'
-      ? 'Press Space to lock the active marker.'
-      : active.status === 'locked'
-      ? 'Press Space again to accept the link.'
+      ? 'Press Space to accept the link.'
       : 'Already linked. Use ←/→ to focus another candidate.'
     : candidatesCount === 0
     ? 'No matches in this pair.'

--- a/src/individual-id/IndividualIdPairHarness.tsx
+++ b/src/individual-id/IndividualIdPairHarness.tsx
@@ -57,6 +57,8 @@ type LinkActor = {
   candidatePos: { x: number; y: number } | null;
   obscured?: boolean;
   oov?: boolean;
+  /** Stamp `noPartnerExpected: true` on a new OOV row. Ignored for existing. */
+  noPartnerExpected?: boolean;
 };
 
 interface Props {
@@ -249,22 +251,6 @@ export function IndividualIdPairHarness({
       }
     },
     [working, currentPairKey, candidates, persistAnnotationPosition]
-  );
-
-  const handleLock = useCallback(
-    (candidateKey: string) => {
-      if (!currentPairKey) return;
-      working.lockCandidate(currentPairKey, candidateKey);
-    },
-    [working, currentPairKey]
-  );
-
-  const handleUnlock = useCallback(
-    (candidateKey: string) => {
-      if (!currentPairKey) return;
-      working.unlockCandidate(currentPairKey, candidateKey);
-    },
-    [working, currentPairKey]
   );
 
   const handlePlaceNew = useCallback(
@@ -515,6 +501,45 @@ export function IndividualIdPairHarness({
     [working, currentPairKey]
   );
 
+  const handleToggleNoPartnerExpected = useCallback(
+    async (annotationId: string) => {
+      const current = localAnnotations.find((a) => a.id === annotationId);
+      if (!current) return;
+      const next = !(current as any).noPartnerExpected;
+      const apply = (a: AnnotationType): AnnotationType =>
+        a.id === annotationId
+          ? ({ ...a, noPartnerExpected: next } as AnnotationType)
+          : a;
+      const revert = (a: AnnotationType): AnnotationType =>
+        a.id === annotationId
+          ? ({
+              ...a,
+              noPartnerExpected: (current as any).noPartnerExpected,
+            } as AnnotationType)
+          : a;
+
+      setLocalAnnotations((prev) => prev.map(apply));
+      patchPairCache((old) => ({
+        ...old,
+        annotations: old.annotations.map(apply),
+      }));
+      try {
+        await client.models.Annotation.update({
+          id: annotationId,
+          noPartnerExpected: next,
+        } as any);
+      } catch (err) {
+        console.error('Failed to toggle noPartnerExpected', err);
+        setLocalAnnotations((prev) => prev.map(revert));
+        patchPairCache((old) => ({
+          ...old,
+          annotations: old.annotations.map(revert),
+        }));
+      }
+    },
+    [localAnnotations, client, patchPairCache]
+  );
+
   // ---- Change-label flow ----
   const allCategories: CategoryType[] =
     (projectCtx as any)?.categoriesHook?.data ?? [];
@@ -702,6 +727,7 @@ export function IndividualIdPairHarness({
             group,
             ...(actor.obscured ? { obscured: true } : {}),
             ...(actor.oov ? { oov: true } : {}),
+            ...(actor.noPartnerExpected ? { noPartnerExpected: true } : {}),
             createdAt: nowIso,
             updatedAt: nowIso,
           } as unknown as AnnotationType);
@@ -830,6 +856,35 @@ export function IndividualIdPairHarness({
     [localAnnotations, commitActorLink]
   );
 
+  const handleMoveToOov = useCallback(
+    async (candidateKey: string, oovSide: 'A' | 'B') => {
+      if (!pair || !currentPairKey) return;
+      const candidate = candidates.find((c) => c.pairKey === candidateKey);
+      if (!candidate) return;
+      const partner = oovSide === 'A' ? candidate.realB : candidate.realA;
+      if (!partner) return;
+      const oovImageId = oovSide === 'A' ? pair.image1Id : pair.image2Id;
+      const actors: LinkActor[] = [
+        {
+          id: partner.id,
+          imageId: partner.imageId,
+          existing: partner,
+          candidatePos: null,
+        },
+        {
+          id: crypto.randomUUID(),
+          imageId: oovImageId,
+          existing: null,
+          candidatePos: { x: 0, y: 0 },
+          oov: true,
+        },
+      ];
+      working.acceptCandidate(currentPairKey, candidateKey);
+      await commitActorLink(actors, candidate.categoryId);
+    },
+    [pair, candidates, working, currentPairKey, commitActorLink]
+  );
+
   const [pendingLink, setPendingLink] = useState<{
     active: string;
     clicked: string;
@@ -927,14 +982,14 @@ export function IndividualIdPairHarness({
           leniency={leniency}
           onLeniencyChange={setLeniency}
           onDrag={handleDrag}
-          onLock={handleLock}
-          onUnlock={handleUnlock}
           onAccept={handleAccept}
           onPlaceNew={handlePlaceNew}
           onDelete={handleDelete}
           onChangeLabel={handleChangeLabel}
           onToggleObscured={handleToggleObscured}
           onSetProposedObscured={handleSetProposedObscured}
+          onMoveToOov={handleMoveToOov}
+          onToggleNoPartnerExpected={handleToggleNoPartnerExpected}
           onManualLinkRequest={requestManualLink}
           onAddOov={handlePlaceOov}
           onRequestPrevPair={goPrev}

--- a/src/individual-id/components/HelpModal.tsx
+++ b/src/individual-id/components/HelpModal.tsx
@@ -18,7 +18,7 @@ function DemoMarker({
   seed = 'detweb-primary',
 }: {
   kind: MarkerKind;
-  status?: 'pending' | 'locked' | 'accepted';
+  status?: 'pending' | 'accepted';
   active?: boolean;
   obscured?: boolean;
   color?: string;
@@ -27,9 +27,7 @@ function DemoMarker({
   const size = 20;
   const shadows: string[] = [];
   if (active) shadows.push('0 0 0 3px #ff8c1a');
-  if (status === 'locked') {
-    shadows.push(active ? '0 0 0 6px #f1c40f' : '0 0 0 3px #f1c40f');
-  } else if (status === 'accepted') {
+  if (status === 'accepted') {
     shadows.push(active ? '0 0 0 6px #27ae60' : '0 0 0 3px #27ae60');
   } else if (!active) {
     shadows.push('0 0 0 1px rgba(0, 0, 0, 0.45)');
@@ -210,13 +208,6 @@ export function HelpModal({ show, onHide }: Props) {
             manual links apply to it.
           </Row>
           <Row
-            demo={<DemoMarker kind='primary' active status='locked' />}
-            label='Locked'
-          >
-            Orange + yellow ring. You have locked the position; pressing Space
-            once more accepts the link.
-          </Row>
-          <Row
             demo={<DemoMarker kind='primary' status='accepted' />}
             label='Accepted'
           >
@@ -304,17 +295,13 @@ export function HelpModal({ show, onHide }: Props) {
           <ol style={{ opacity: 0.9, fontSize: 14, paddingLeft: 18 }}>
             <li className='mb-2'>
               Press <strong>Space</strong>. The next candidate becomes active
-              (orange) and both images pan to it.
-            </li>
-            <li className='mb-2'>
-              If a marker is already active, Space <strong>locks</strong> it
-              (yellow ring) and pans to it. Before locking, you can drag the
-              real marker and the proposed marker to line them up precisely.
+              (orange) and both images pan to it. Drag the real marker and
+              the proposed marker to line them up precisely.
             </li>
             <li className='mb-2'>
               Press <strong>Space</strong> again to{' '}
               <strong>accept</strong> the pair (green ring) — the two markers
-              are now linked.
+              are now linked, and focus advances to the next candidate.
             </li>
           </ol>
           <p style={{ opacity: 0.85, fontSize: 14, marginBottom: 0 }}>

--- a/src/individual-id/components/OovPanel.tsx
+++ b/src/individual-id/components/OovPanel.tsx
@@ -18,6 +18,8 @@ interface Props {
   onHoverChange: (candidateKey: string | null) => void;
   /** Delete the OOV row underlying this card. */
   onDelete: (candidateKey: string) => void;
+  /** Toggle the `noPartnerExpected` flag on the OOV row. */
+  onToggleNoPartnerExpected: (annotationId: string) => void;
 }
 
 const COLLAPSED_WIDTH = 38;
@@ -34,6 +36,7 @@ export function OovPanel({
   onCtrlClick,
   onHoverChange,
   onDelete,
+  onToggleNoPartnerExpected,
 }: Props) {
   const [collapsed, setCollapsed] = useState(false);
 
@@ -139,6 +142,7 @@ export function OovPanel({
               onCtrlClick={onCtrlClick}
               onHoverChange={onHoverChange}
               onDelete={onDelete}
+              onToggleNoPartnerExpected={onToggleNoPartnerExpected}
             />
           )
         )}
@@ -238,6 +242,7 @@ function OovCard({
   onCtrlClick,
   onHoverChange,
   onDelete,
+  onToggleNoPartnerExpected,
 }: {
   candidate: MatchCandidate;
   side: 'A' | 'B';
@@ -249,6 +254,7 @@ function OovCard({
   onCtrlClick: (key: string) => void;
   onHoverChange: (key: string | null) => void;
   onDelete: (key: string) => void;
+  onToggleNoPartnerExpected: (annotationId: string) => void;
 }) {
   const real = side === 'A' ? candidate.realA : candidate.realB;
   const isPrimary = !real?.objectId || real.objectId === real.id;
@@ -263,20 +269,24 @@ function OovCard({
   // row to remove yet, and silently no-op'ing the button would be misleading.
   const showActions = hover && !isProposed;
 
+  // Terminus: accepted via `noPartnerExpected` rather than a real partner.
+  // Other side of the candidate is empty (no `realA`/`realB` opposite).
+  const otherSideReal = side === 'A' ? candidate.realB : candidate.realA;
+  const isTerminus =
+    candidate.status === 'accepted' && !otherSideReal && !isProposed;
+
   const statusColor = isProposed
     ? '#ffa500'
     : candidate.status === 'accepted'
     ? '#27ae60'
-    : candidate.status === 'locked'
-    ? '#f1c40f'
     : '#888';
   const statusLabel = isProposed
     ? 'Proposed'
+    : isTerminus
+    ? 'No link required'
     : candidate.status === 'accepted'
     ? 'Linked'
-    : candidate.status === 'pending'
-    ? 'Needs link'
-    : 'Locked';
+    : 'Needs link';
 
   const handleClick = (ev: React.MouseEvent) => {
     if ((ev.ctrlKey || ev.metaKey) && ev.button === 0) {
@@ -383,6 +393,36 @@ function OovCard({
       >
         {statusLabel}
       </div>
+      {/* Terminus toggle: only meaningful for partnerless DB OOVs. A
+          partnered OOV is already accepted via its link, so the flag is
+          moot; a chain-proposed OOV has no DB row to update yet. */}
+      {!isProposed && !otherSideReal && real && (
+        <button
+          type='button'
+          onClick={(ev) => {
+            ev.stopPropagation();
+            onToggleNoPartnerExpected(real.id);
+          }}
+          title={
+            isTerminus
+              ? 'Allow this OOV to require a partner on neighbour pairs again'
+              : 'Mark this OOV as a chain terminus — no partner expected on any neighbour'
+          }
+          style={{
+            background: '#ff8c1a',
+            color: '#fff',
+            border: '1px solid #ff8c1a',
+            borderRadius: 4,
+            padding: '2px 6px',
+            fontSize: 10,
+            fontWeight: 600,
+            cursor: 'pointer',
+            alignSelf: 'flex-start',
+          }}
+        >
+          {isTerminus ? 'Require link' : 'No link required'}
+        </button>
+      )}
       {showActions && (
         <button
           type='button'

--- a/src/individual-id/hooks/usePairWorkingState.ts
+++ b/src/individual-id/hooks/usePairWorkingState.ts
@@ -7,7 +7,7 @@ type CandidateKey = string;
 interface CandidateOverride {
   posA?: { x: number; y: number };
   posB?: { x: number; y: number };
-  status?: 'pending' | 'locked' | 'accepted';
+  status?: 'pending' | 'accepted';
   obscuredA?: boolean;
   obscuredB?: boolean;
   rejected?: boolean;
@@ -18,9 +18,7 @@ export interface PairWorkingState {
   mergeCandidates: (pairKey: PairKey, fresh: MatchCandidate[]) => MatchCandidate[];
   setCandidatePosition: (pairKey: PairKey, candidateKey: CandidateKey, side: 'A' | 'B', pos: { x: number; y: number }) => void;
   setCandidateObscured: (pairKey: PairKey, candidateKey: CandidateKey, side: 'A' | 'B', value: boolean) => void;
-  lockCandidate: (pairKey: PairKey, candidateKey: CandidateKey) => void;
   acceptCandidate: (pairKey: PairKey, candidateKey: CandidateKey) => void;
-  unlockCandidate: (pairKey: PairKey, candidateKey: CandidateKey) => void;
   rejectCandidate: (pairKey: PairKey, candidateKey: CandidateKey) => void;
   clearPair: (pairKey: PairKey) => void;
   hasUnsavedWork: (pairKey: PairKey) => boolean;
@@ -109,18 +107,8 @@ export function usePairWorkingState(): PairWorkingState {
       [updateCandidate]
     );
 
-  const lockCandidate: PairWorkingState['lockCandidate'] = useCallback(
-    (pk, ck) => updateCandidate(pk, ck, (prev) => ({ ...prev, status: 'locked' })),
-    [updateCandidate]
-  );
-
   const acceptCandidate: PairWorkingState['acceptCandidate'] = useCallback(
     (pk, ck) => updateCandidate(pk, ck, (prev) => ({ ...prev, status: 'accepted' })),
-    [updateCandidate]
-  );
-
-  const unlockCandidate: PairWorkingState['unlockCandidate'] = useCallback(
-    (pk, ck) => updateCandidate(pk, ck, (prev) => ({ ...prev, status: 'pending' })),
     [updateCandidate]
   );
 
@@ -143,7 +131,6 @@ export function usePairWorkingState(): PairWorkingState {
     for (const ov of pair.values()) {
       if (ov.posA || ov.posB) return true;
       if (ov.obscuredA || ov.obscuredB) return true;
-      if (ov.status && ov.status !== 'pending' && ov.status !== 'accepted') return true;
     }
     return false;
   }, []);
@@ -154,9 +141,7 @@ export function usePairWorkingState(): PairWorkingState {
       mergeCandidates,
       setCandidatePosition,
       setCandidateObscured,
-      lockCandidate,
       acceptCandidate,
-      unlockCandidate,
       rejectCandidate,
       clearPair,
       hasUnsavedWork,
@@ -166,9 +151,7 @@ export function usePairWorkingState(): PairWorkingState {
       mergeCandidates,
       setCandidatePosition,
       setCandidateObscured,
-      lockCandidate,
       acceptCandidate,
-      unlockCandidate,
       rejectCandidate,
       clearPair,
       hasUnsavedWork,

--- a/src/individual-id/types.ts
+++ b/src/individual-id/types.ts
@@ -31,10 +31,9 @@ export interface NeighbourPair {
  * Status of a single annotation candidate inside a pair.
  *
  * `pending`  — proposed by Munkres or moved by the user, NOT committed yet.
- * `locked`   — user pressed space once: position is frozen for this candidate.
- * `accepted` — user pressed space twice: objectId written to DB on both sides.
+ * `accepted` — user pressed Space: objectId written to DB on both sides.
  */
-export type CandidateStatus = 'pending' | 'locked' | 'accepted';
+export type CandidateStatus = 'pending' | 'accepted';
 
 /**
  * A single match candidate inside a pair: zero, one, or two real annotations

--- a/src/individual-id/utils/munkres.ts
+++ b/src/individual-id/utils/munkres.ts
@@ -253,6 +253,9 @@ export function buildMatchCandidates({
     } else {
       // OOV ↔ OOV bridges a multi-image gap; posA/posB stay null because
       // oovPartner.{x,y} are the (0,0) placeholder, not real coordinates.
+      // `noPartnerExpected` flags an OOV that terminates its chain — no
+      // partner is required, so we accept it as-is rather than nag every
+      // pair containing this image.
       candidates.push({
         pairKey,
         categoryId: o.categoryId,
@@ -262,7 +265,8 @@ export function buildMatchCandidates({
         posB: null,
         isShadowA: false,
         isShadowB: false,
-        status: oovPartner ? 'accepted' : 'pending',
+        status:
+          oovPartner || (o as any).noPartnerExpected ? 'accepted' : 'pending',
         oovSide: side,
       });
     }


### PR DESCRIPTION
- Removed the intermediate "lock" step from the Space-key workflow (Space now goes pending → accepted directly).
- Updated HelpModal + toolbar copy to reflect the two-step flow.
- Added `noPartnerExpected` boolean to the Annotation schema.
- New "Move to OOV" action on a shadow popup: when the candidate has a real partner on the other side, materialises an OOV chain-linked to that partner (without auto-setting noPartnerExpected).
- New per-card "No link required" / "Require link" toggle in the OovPanel (orange primary), visible only for partnerless DB-backed OOVs - lets the user mark a chain terminus once they've confirmed the animal is genuinely absent everywhere.