### PR TITLE
fix: make individual-id link accept advance and pan instantly

### DIFF
--- a/src/individual-id/IndividualIdHarness.tsx
+++ b/src/individual-id/IndividualIdHarness.tsx
@@ -1639,20 +1639,27 @@ export function IndividualIdHarness({
 
       // Fire writes (non-blocking). Strip createdAt/updatedAt — Amplify
       // auto-manages those and CreateAnnotationInput rejects them.
-      try {
-        await Promise.all([
-          ...updates.map((u) =>
-            client.models.Annotation.update({ id: u.id, ...u.patch } as any)
-          ),
-          ...newRows.map((row) => {
-            const { createdAt: _c, updatedAt: _u, ...dbInput } = row as any;
-            return client.models.Annotation.create(dbInput as any);
-          }),
-        ]);
-      } catch (err) {
+      //
+      // We deliberately do NOT await the round-trip: the optimistic local
+      // update above is the session source of truth, and callers use the
+      // return value only to advance focus to the next marker. Awaiting
+      // AppSync here stalled that advance by a visible ~1s and — because the
+      // accepted candidate's pairKey changes once it gains an objectId — gave
+      // the stale-activeKey cleanup time to fire, which reset the pan baseline
+      // and suppressed the pan to the next marker. Failures only log; there's
+      // no rollback to sequence.
+      void Promise.all([
+        ...updates.map((u) =>
+          client.models.Annotation.update({ id: u.id, ...u.patch } as any)
+        ),
+        ...newRows.map((row) => {
+          const { createdAt: _c, updatedAt: _u, ...dbInput } = row as any;
+          return client.models.Annotation.create(dbInput as any);
+        }),
+      ]).catch((err) => {
         // eslint-disable-next-line no-console
         console.error('Failed to commit individual-id link', err);
-      }
+      });
       return true;
     },
     [

--- a/src/individual-id/IndividualIdMapPair.tsx
+++ b/src/individual-id/IndividualIdMapPair.tsx
@@ -629,6 +629,14 @@ export function IndividualIdMapPair(props: Props) {
           }
         }
         setActiveKey(nearest.pairKey);
+        // Pan explicitly instead of leaning on the active-key effect. The
+        // just-accepted candidate's pairKey changes the moment its link is
+        // written (it gains an objectId), so `activeKey` briefly points at a
+        // stale key and the cleanup effect nulls it — which makes the pan
+        // effect treat this as an initial activation and skip panning. The
+        // viewport check inside panToCandidate still suppresses the pan when
+        // `nearest` is already on screen.
+        panToCandidate(nearest.pairKey);
       }
       return;
     }


### PR DESCRIPTION
Accepting a link stalled ~1s before the next marker activated and then failed to pan to it when off-screen. Both stemmed from the accept path waiting on the network: commitActorLink awaited the AppSync writes before returning, so focus advance was blocked on the round-trip, and that delay let the stale-activeKey cleanup fire — resetting the pan baseline so the pan effect treated the next marker as an initial activation and skipped it.

Fire the annotation writes without awaiting (the optimistic local update is already the source of truth; there was no rollback to sequence) and pan to the nearest candidate explicitly in the accept branch rather than relying on the active-key effect, whose key changes when the accepted candidate gains an objectId. The viewport check still suppresses the pan when the next marker is already on screen.