### PR TITLE
fix: use refreshable credentials and reset visibility on error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ dist-ssr
 *.sln
 *.sw?
 
+# Python
+__pycache__/
+*.pyc
+
 # amplify
 amplify_outputs*
 amplifyconfiguration*

--- a/containerImages/stormflyDetector/code/processSQS.py
+++ b/containerImages/stormflyDetector/code/processSQS.py
@@ -28,13 +28,13 @@ BOX_SIZE = int(os.environ.get('STORMFLY_BOX_SIZE', '64'))
 
 sqs = boto3.client('sqs', region_name=REGION)
 s3 = boto3.client('s3', region_name=REGION)
-credentials = boto3.Session().get_credentials().get_frozen_credentials()
+# ECS task-role credentials rotate every few hours; passing the refreshable
+# botocore credentials object (instead of a frozen snapshot) makes AWS4Auth
+# re-read keys on every request, so long-lived workers keep signing correctly.
 auth = AWS4Auth(
-    credentials.access_key,
-    credentials.secret_key,
-    REGION,
-    'appsync',
-    session_token=credentials.token,
+    region=REGION,
+    service='appsync',
+    refreshable_credentials=boto3.Session().get_credentials(),
 )
 client = Client(
     transport=RequestsHTTPTransport(
@@ -157,6 +157,20 @@ def main():
                 )
             except Exception as error:
                 print(f'Error processing Stormfly message: {error}', flush=True)
+                # Release the message immediately so retries (and eventual DLQ
+                # redrive) happen promptly instead of after the full 30-minute
+                # visibility timeout.
+                try:
+                    sqs.change_message_visibility(
+                        QueueUrl=QUEUE_URL,
+                        ReceiptHandle=message['ReceiptHandle'],
+                        VisibilityTimeout=0,
+                    )
+                except ClientError as visibility_error:
+                    print(
+                        f'Failed to reset message visibility: {visibility_error}',
+                        flush=True,
+                    )
         if 'Messages' not in response:
             time.sleep(5)
 

--- a/containerImages/stormflyDetector/code/requirements.txt
+++ b/containerImages/stormflyDetector/code/requirements.txt
@@ -3,5 +3,5 @@ gql[all]
 numpy>=1.24
 onnxruntime-gpu>=1.20
 pillow>=9.0
-requests_aws4auth
+requests_aws4auth>=1.2
 


### PR DESCRIPTION
Switch AWS4Auth initialization from a frozen credential snapshot to a refreshable credentials object so long-lived ECS workers continue to sign AppSync requests correctly after IAM task-role credentials rotate.

On processing failure, immediately reset the SQS message visibility timeout to 0 so retries and DLQ redrive happen promptly rather than waiting out the full visibility window. Also pin requests_aws4auth to
>=1.2 (minimum version supporting the refreshable_credentials API) and
add Python cache files to .gitignore.