### PR TITLE
fix: include reunion check in ChainLinker launch completeness

### DIFF
--- a/src/individual-id/IndividualIdHarness.tsx
+++ b/src/individual-id/IndividualIdHarness.tsx
@@ -346,19 +346,24 @@ export function IndividualIdHarness({
   // where the animal may have come back into view. The user is then
   // forced through those synthetic pairs before the transect completes;
   // when they finish a round, we search again (chains may have merged
-  // and exposed new endpoints). `reviewedReunionsRef` prevents loops on
-  // pairs the user already saw without taking action.
+  // and exposed new endpoints). `reviewedReunionsRef` records, per image
+  // pair, the pending candidate keys that were on screen when the user
+  // confirmed the dialog — a pair only re-surfaces in a later round when
+  // merges have produced pendings the user has NOT seen, so unchanged
+  // pairs can't loop but new possible links still come back for review.
   const [reunionMode, setReunionMode] = useState<{
     pairs: NeighbourPairWithMeta[];
   } | null>(null);
   const [pendingReunionDialog, setPendingReunionDialog] = useState<{
     pairs: NeighbourPairWithMeta[];
+    /** reviewKey (imageA|imageB) → pending candidate keys shown this round. */
+    pendingKeysByPair: Map<string, Set<string>>;
   } | null>(null);
   // Final "you're done" gate — set when the completion detector decides
   // the transect is closed. Confirmation fires `onComplete`; the parent
   // navigates the user back to Jobs.
   const [showTransectComplete, setShowTransectComplete] = useState(false);
-  const reviewedReunionsRef = useRef<Set<string>>(new Set());
+  const reviewedReunionsRef = useRef<Map<string, Set<string>>>(new Map());
 
   // Fabricate a `NeighbourPairWithMeta` from a `ReunionCandidate`. There's
   // no DB `ImageNeighbour` row backing a synthetic pair, but nothing
@@ -604,25 +609,25 @@ export function IndividualIdHarness({
       leniency,
       maxHops: REUNION_MAX_HOPS,
     });
-    // Skip pairs the user has already been shown — prevents an infinite
-    // loop when a user reviews a pair without making changes (no chain
-    // merge ⇒ same candidates re-appear on the next search).
-    const fresh = candidates.filter(
-      (c) =>
-        !reviewedReunionsRef.current.has(`${c.imageAId}|${c.imageBId}`)
-    );
-    const newPairs = fresh
-      .map((c) => synthesiseReunionPair(c, imagesById))
-      .filter((p): p is NeighbourPairWithMeta => p !== null);
-
     // `findReunions` only checks "is there a cross-chain annotation near
     // the endpoint projection?" — but the full Munkres assignment on the
     // synthetic pair can still come out all-accepted (a same-objectId
     // annotation outbidding the cross-chain one) or all-informational.
     // Pre-run Munkres so the dialog count is what the user will actually
-    // have to action; mark drops as reviewed so we don't re-evaluate them.
+    // have to action.
+    //
+    // Already-reviewed pairs are skipped by PENDING-CANDIDATE comparison,
+    // not by image pair: a round's chain merges can mint brand-new pending
+    // candidates on a pair the user already walked through, and those must
+    // come back for review. (Merges also rewrite objectIds, which are part
+    // of candidate keys, so a merge touching a reviewed pair makes its
+    // pendings look new and re-surfaces it — conservative in the right
+    // direction, since the merge changed the context of the decision.)
     const actionable: NeighbourPairWithMeta[] = [];
-    for (const p of newPairs) {
+    const pendingKeysByPair = new Map<string, Set<string>>();
+    for (const c of candidates) {
+      const p = synthesiseReunionPair(c, imagesById);
+      if (!p) continue;
       const pairKey = makePairKey(p.image1Id, p.image2Id);
       const built = buildMatchCandidates({
         annotationsA: annotationsByImage[p.image1Id] ?? [],
@@ -635,11 +640,26 @@ export function IndividualIdHarness({
         categoryFilter: categoryId,
       });
       const merged = working.mergeCandidates(pairKey, built);
-      if (evaluatePairCompletion(merged).status === 'incomplete') {
-        actionable.push(p);
-      } else {
-        reviewedReunionsRef.current.add(`${p.image1Id}|${p.image2Id}`);
+      if (evaluatePairCompletion(merged).status !== 'incomplete') continue;
+      const pending = new Set(
+        merged
+          .filter((m) => !m.informational && m.status !== 'accepted')
+          .map((m) => m.pairKey)
+      );
+      const reviewKey = `${p.image1Id}|${p.image2Id}`;
+      const seen = reviewedReunionsRef.current.get(reviewKey);
+      if (seen) {
+        let hasNew = false;
+        for (const k of pending) {
+          if (!seen.has(k)) {
+            hasNew = true;
+            break;
+          }
+        }
+        if (!hasNew) continue;
       }
+      actionable.push(p);
+      pendingKeysByPair.set(reviewKey, pending);
     }
 
     if (actionable.length === 0) {
@@ -647,7 +667,7 @@ export function IndividualIdHarness({
       setShowTransectComplete(true);
       return;
     }
-    setPendingReunionDialog({ pairs: actionable });
+    setPendingReunionDialog({ pairs: actionable, pendingKeysByPair });
   }, [
     chainObjectId,
     pairViews,
@@ -665,13 +685,22 @@ export function IndividualIdHarness({
   ]);
 
   // The reunion dialog has no skip button — confirmation always enters
-  // review mode. The image pairs are stamped into `reviewedReunionsRef`
-  // here so the user only sees each one once per session, even if they
-  // walk away without changing anything.
+  // review mode. The pending candidate keys shown for each pair are
+  // stamped into `reviewedReunionsRef` here (unioned with any earlier
+  // round's), so a pair the user saw and left untouched is never re-shown,
+  // while later merges that mint unseen pendings on it re-surface it.
   const confirmReunionDialog = useCallback(() => {
     if (!pendingReunionDialog) return;
     for (const p of pendingReunionDialog.pairs) {
-      reviewedReunionsRef.current.add(`${p.image1Id}|${p.image2Id}`);
+      const reviewKey = `${p.image1Id}|${p.image2Id}`;
+      const pending = pendingReunionDialog.pendingKeysByPair.get(reviewKey);
+      if (!pending) continue;
+      const seen = reviewedReunionsRef.current.get(reviewKey);
+      if (seen) {
+        for (const k of pending) seen.add(k);
+      } else {
+        reviewedReunionsRef.current.set(reviewKey, new Set(pending));
+      }
     }
     setReunionMode({ pairs: pendingReunionDialog.pairs });
     setPendingReunionDialog(null);

--- a/src/individual-id/utils/transectCompletion.ts
+++ b/src/individual-id/utils/transectCompletion.ts
@@ -6,17 +6,28 @@ import type {
 import { buildNeighbourTransforms } from './transforms';
 import { buildMatchCandidates } from './munkres';
 import { evaluatePairCompletion } from './completion';
+import { findReunions } from './reunionSearch';
 
 // Must match IndividualIdHarness DEFAULT_LENIENCY so launch-time completeness agrees with runtime.
 export const DEFAULT_INDIVIDUAL_ID_LENIENCY = 40;
+
+// Must match IndividualIdHarness REUNION_MAX_HOPS so launch-time reunion search agrees with runtime.
+export const DEFAULT_REUNION_MAX_HOPS = 20;
 
 export interface TransectCompletenessInput {
   imagesById: Record<string, ImageType>;
   imageIdsByTransect: Map<string, Set<string>>;
   rawNeighbours: ImageNeighbourType[];
+  /**
+   * Annotations for ALL categories, not just the launch category. Direct-pair
+   * evaluation filters via `categoryFilter` internally; reunion search needs
+   * the full set so chain membership (via shared objectIds) matches what the
+   * harness sees at runtime.
+   */
   annotationsByImage: Record<string, AnnotationType[]>;
   categoryId: string;
   leniency?: number;
+  maxHops?: number;
 }
 
 // Pair orientation is irrelevant — swapping A/B also swaps forward/backward, so candidate sets are invariant.
@@ -31,6 +42,7 @@ export function findIncompleteTransectIds(
     categoryId,
   } = input;
   const leniency = input.leniency ?? DEFAULT_INDIVIDUAL_ID_LENIENCY;
+  const maxHops = input.maxHops ?? DEFAULT_REUNION_MAX_HOPS;
 
   const transectOf = new Map<string, string>();
   for (const [tId, ids] of imageIdsByTransect) {
@@ -76,7 +88,85 @@ export function findIncompleteTransectIds(
         break;
       }
     }
-    if (hasPair && anyIncomplete) incomplete.push(tId);
+    if (!hasPair) continue;
+    if (anyIncomplete) {
+      incomplete.push(tId);
+      continue;
+    }
+    // Every direct pair is complete — mirror the harness's completion
+    // detector: the transect only counts as done if reunion search surfaces
+    // no actionable synthetic pairs. Otherwise a transect whose annotations
+    // are all linked but whose chains still need merging would block launch.
+    if (
+      hasIncompleteReunion({
+        transectImageIds: imageIdsByTransect.get(tId),
+        neighbours,
+        imagesById,
+        annotationsByImage,
+        categoryId,
+        leniency,
+        maxHops,
+      })
+    ) {
+      incomplete.push(tId);
+    }
   }
   return incomplete;
+}
+
+// Mirrors the actionability filter in IndividualIdHarness's completion
+// detector: a reunion candidate only counts when the Munkres pass over the
+// synthetic pair actually leaves work to do (it can come out all-accepted or
+// all-informational, in which case the harness silently drops it too).
+function hasIncompleteReunion({
+  transectImageIds,
+  neighbours,
+  imagesById,
+  annotationsByImage,
+  categoryId,
+  leniency,
+  maxHops,
+}: {
+  transectImageIds: Set<string> | undefined;
+  neighbours: ImageNeighbourType[];
+  imagesById: Record<string, ImageType>;
+  annotationsByImage: Record<string, AnnotationType[]>;
+  categoryId: string;
+  leniency: number;
+  maxHops: number;
+}): boolean {
+  if (!transectImageIds) return false;
+  const annotations: AnnotationType[] = [];
+  for (const imageId of transectImageIds) {
+    const anns = annotationsByImage[imageId];
+    if (anns) annotations.push(...anns);
+  }
+  if (annotations.length === 0) return false;
+
+  const candidates = findReunions({
+    annotations,
+    rawNeighbours: neighbours,
+    imagesById,
+    categoryId,
+    leniency,
+    maxHops,
+  });
+
+  for (const c of candidates) {
+    const imageA = imagesById[c.imageAId];
+    const imageB = imagesById[c.imageBId];
+    if (!imageA || !imageB) continue;
+    const built = buildMatchCandidates({
+      annotationsA: annotationsByImage[c.imageAId] ?? [],
+      annotationsB: annotationsByImage[c.imageBId] ?? [],
+      imageA,
+      imageB,
+      forward: c.forward,
+      backward: c.backward,
+      leniency,
+      categoryFilter: categoryId,
+    });
+    if (evaluatePairCompletion(built).status === 'incomplete') return true;
+  }
+  return false;
 }

--- a/src/survey/IndividualId.tsx
+++ b/src/survey/IndividualId.tsx
@@ -57,9 +57,12 @@ type AnnotationRow = {
   oov: boolean | null;
 };
 
+// timestamp/originalPath drive the reunion search's chronological endpoint
+// ordering — without them every image falls back to id order and the
+// launch-time check could disagree with the harness.
 type ImageWithNeighbours = Pick<
   ImageType,
-  'id' | 'width' | 'height' | 'transectId'
+  'id' | 'width' | 'height' | 'transectId' | 'timestamp' | 'originalPath'
 > & {
   leftNeighbours?: ImageNeighbourType[] | null;
   rightNeighbours?: ImageNeighbourType[] | null;
@@ -188,9 +191,11 @@ export default function IndividualId({
     let cancelled = false;
     const timer = setTimeout(() => {
       if (cancelled) return;
+      // Deliberately unfiltered by category: direct-pair evaluation filters
+      // internally, and the reunion search needs every annotation so chain
+      // membership matches what the harness sees at runtime.
       const annotationsByImage: Record<string, AnnotationType[]> = {};
       for (const a of allAnnotations) {
-        if (a.categoryId !== selectedCategoryId) continue;
         (annotationsByImage[a.imageId] ??= []).push(
           a as unknown as AnnotationType
         );
@@ -570,6 +575,8 @@ async function fetchProjectImages(
         'width',
         'height',
         'transectId',
+        'timestamp',
+        'originalPath',
         'leftNeighbours.*',
         'rightNeighbours.*',
       ],


### PR DESCRIPTION
Launching a ChainLinker task gated each transect on direct neighbour pairs only, so a transect whose annotations were all linked but still had unfinished reunions counted as complete and blocked the launch. findIncompleteTransectIds now mirrors the harness's completion detector: when every direct pair is complete it runs the same reunion search and flags the transect if any synthetic pair is still actionable after a Munkres pass. The launch modal feeds it unfiltered annotations (chain membership spans categories) and now fetches image timestamp/originalPath so reunion endpoint ordering matches runtime.

Also rework the harness's reviewed-reunion tracking to record the pending candidate keys shown per image pair instead of just the pair: chain merges from a finished round can mint new pending candidates on an already-reviewed pair, and those now re-surface for review, while pairs the user saw and left untouched still cannot loop.