### PR TITLE
fix: require project ID in Stormfly mutations

### DIFF
--- a/containerImages/stormflyDetector/code/processSQS.py
+++ b/containerImages/stormflyDetector/code/processSQS.py
@@ -41,7 +41,7 @@ client = Client(
 )
 
 create_location = gql("""
-mutation CreateLocation($confidence: Float, $height: Int, $imageId: ID!, $projectId: ID="", $setId: ID!, $source: String!, $width: Int, $x: Int!, $y: Int!) {
+mutation CreateLocation($confidence: Float, $height: Int, $imageId: ID!, $projectId: ID!, $setId: ID!, $source: String!, $width: Int, $x: Int!, $y: Int!) {
   createLocation(input: {confidence: $confidence, height: $height, imageId: $imageId, projectId: $projectId, setId: $setId, source: $source, x: $x, y: $y, width: $width}) {
     id
   }
@@ -109,7 +109,7 @@ LOCATION_BATCH = 25
 def _write_locations(body, image_id, points, size):
     for start in range(0, len(points), LOCATION_BATCH):
         chunk = points[start:start + LOCATION_BATCH]
-        var_defs = ['$imageId: ID!', '$projectId: ID', '$setId: ID!',
+        var_defs = ['$imageId: ID!', '$projectId: ID!', '$setId: ID!',
                     '$source: String!', '$size: Int']
         fields = []
         variables = {

--- a/containerImages/stormflyDetector/code/test_stormfly_detector.py
+++ b/containerImages/stormflyDetector/code/test_stormfly_detector.py
@@ -1,6 +1,7 @@
 import sys
 import types
 import unittest
+from pathlib import Path
 
 import numpy as np
 from PIL import Image
@@ -8,6 +9,15 @@ from PIL import Image
 sys.modules.setdefault('onnxruntime', types.SimpleNamespace())
 
 from stormfly_detector import StormflyDetector
+
+
+class StormflyGraphQLTests(unittest.TestCase):
+    def test_required_location_ids_use_non_null_graphql_variables(self):
+        source = Path(__file__).with_name('processSQS.py').read_text()
+
+        self.assertNotIn('$projectId: ID=""', source)
+        self.assertNotIn("'$projectId: ID'", source)
+        self.assertGreaterEqual(source.count('$projectId: ID!'), 2)
 
 
 class StormflyDetectorOrientationTests(unittest.TestCase):


### PR DESCRIPTION
Match the GraphQL variable nullability to `CreateLocationInput` for single and batched location writes.

Add a regression test covering both mutation paths.