### PR TITLE
feat: expose ChainLinker workflows

### DIFF
--- a/src/AnnotationSetResults.tsx
+++ b/src/AnnotationSetResults.tsx
@@ -3,7 +3,7 @@ import { Modal, Body, Header, Footer, Title } from './Modal';
 import { useNavigate } from 'react-router-dom';
 import { fetchAllPaginatedResults } from './utils.tsx';
 import exportFromJSON from 'export-from-json';
-import { GlobalContext, UserContext } from './Context.tsx';
+import { GlobalContext } from './Context.tsx';
 import { useContext, useState, useEffect, useMemo } from 'react';
 import { useUsers } from './apiInterface';
 import GenerateJollyResults from './GenerateJollyResults.tsx';
@@ -22,8 +22,6 @@ export default function AnnotationSetResults({
 }) {
   const navigate = useNavigate();
   const { client, showModal } = useContext(GlobalContext)!;
-  const { cognitoGroups } = useContext(UserContext)!;
-  const isSysadmin = cognitoGroups.includes('sysadmin');
   const [loading, setLoading] = useState(false);
   const [exportStatus, setExportStatus] = useState('');
   const { users } = useUsers();
@@ -250,26 +248,24 @@ export default function AnnotationSetResults({
                 Download
               </Button>
             </div>
-            {isSysadmin && (
-              <div>
-                <h5 className='mb-0'>Chain Viewer</h5>
-                <span className='text-muted' style={{ fontSize: '14px' }}>
-                  Inspect linked-individual chains: every primary annotation
-                  and all its linked sightings across neighbour images.
-                </span>
-                <Button
-                  className='d-block mt-1'
-                  variant='primary'
-                  onClick={() =>
-                    navigate(
-                      `/surveys/${surveyId}/set/${annotationSet.id}/chain-viewer`
-                    )
-                  }
-                >
-                  Open Chain Viewer
-                </Button>
-              </div>
-            )}
+            <div>
+              <h5 className='mb-0'>Chain Viewer</h5>
+              <span className='text-muted' style={{ fontSize: '14px' }}>
+                Inspect linked-individual chains: every primary annotation
+                and all its linked sightings across neighbour images.
+              </span>
+              <Button
+                className='d-block mt-1'
+                variant='primary'
+                onClick={() =>
+                  navigate(
+                    `/surveys/${surveyId}/set/${annotationSet.id}/chain-viewer`
+                  )
+                }
+              >
+                Open Chain Viewer
+              </Button>
+            </div>
             <div>
               <h5 className='mb-0'>Jolly II</h5>
               <span className='text-muted' style={{ fontSize: '14px' }}>

--- a/src/survey/LaunchAnnotationSetModal.tsx
+++ b/src/survey/LaunchAnnotationSetModal.tsx
@@ -3,7 +3,7 @@ import { Modal, Body, Header, Footer, Title } from '../Modal';
 import { useState, useContext, useEffect } from 'react';
 import { Tabs, Tab } from '../Tabs';
 import { Schema } from '../amplify/client-schema';
-import { GlobalContext, UserContext } from '../Context';
+import { GlobalContext } from '../Context';
 import SpeciesLabelling from './SpeciesLabelling';
 import FalseNegatives from './FalseNegatives';
 import QCReview from './QCReview';
@@ -45,18 +45,14 @@ export default function LaunchAnnotationSetModal({
 
   // set up queue creation helper
   const { client, showModal } = useContext(GlobalContext)! as any;
-  const { cognitoGroups } = useContext(UserContext)!;
-  const isSysadmin = cognitoGroups.includes('sysadmin');
 
-  // Task type for each tab, in render order. The Individual ID tab is only
-  // shown to sysadmins, so its presence shifts subsequent tab indices.
+  // Task type for each tab, in render order.
   const tabTaskTypes: TaskType[] = [
     'species-labelling',
     'false-negatives',
     'qc-review',
     'homographies',
-    ...(isSysadmin ? (['individual-id'] as TaskType[]) : []),
-    'registration',
+    'individual-id',
   ];
 
   useEffect(() => {
@@ -191,25 +187,16 @@ export default function LaunchAnnotationSetModal({
                 setHomographyLaunchHandler={setHomographyLaunchHandler as any}
               />
             </Tab>
-            {isSysadmin && (
-              <Tab label='ChainLinker'>
-                <IndividualId
-                  project={project}
-                  annotationSet={annotationSet}
-                  launching={launching}
-                  setLaunchDisabled={setLaunchDisabled}
-                  setIndividualIdLaunchHandler={
-                    setIndividualIdLaunchHandler as any
-                  }
-                />
-              </Tab>
-            )}
-            <Tab label='Registration'>
-              <div className='p-3'>
-                <p className='m-0'>
-                  This will launch a registration task for the annotation set.
-                </p>
-              </div>
+            <Tab label='ChainLinker'>
+              <IndividualId
+                project={project}
+                annotationSet={annotationSet}
+                launching={launching}
+                setLaunchDisabled={setLaunchDisabled}
+                setIndividualIdLaunchHandler={
+                  setIndividualIdLaunchHandler as any
+                }
+              />
             </Tab>
           </Tabs>
         </Form>


### PR DESCRIPTION
Make the Chain Viewer action and ChainLinker launch tab available to all users by removing the sysadmin-only gates.

Drop the placeholder registration tab from the launch modal so tab ordering maps directly to the available task types.